### PR TITLE
[Step1] 체크 게임 설계 및 Pawn 테스트 추가

### DIFF
--- a/ChessGame.xcodeproj/project.pbxproj
+++ b/ChessGame.xcodeproj/project.pbxproj
@@ -1,0 +1,665 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		C238560F2860550E000F182B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238560E2860550E000F182B /* AppDelegate.swift */; };
+		C23856112860550E000F182B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23856102860550E000F182B /* SceneDelegate.swift */; };
+		C23856132860550E000F182B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23856122860550E000F182B /* ViewController.swift */; };
+		C23856162860550E000F182B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C23856142860550E000F182B /* Main.storyboard */; };
+		C23856182860550F000F182B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C23856172860550F000F182B /* Assets.xcassets */; };
+		C238561B2860550F000F182B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C23856192860550F000F182B /* LaunchScreen.storyboard */; };
+		C238562628605510000F182B /* ChessGameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238562528605510000F182B /* ChessGameTests.swift */; };
+		C238563028605510000F182B /* ChessGameUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238562F28605510000F182B /* ChessGameUITests.swift */; };
+		C238563228605510000F182B /* ChessGameUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238563128605510000F182B /* ChessGameUITestsLaunchTests.swift */; };
+		C238563F286055A5000F182B /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238563E286055A5000F182B /* Board.swift */; };
+		C2385640286055A5000F182B /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238563E286055A5000F182B /* Board.swift */; };
+		C2385643286055E1000F182B /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2385642286055E1000F182B /* Pawn.swift */; };
+		C2385644286055E1000F182B /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2385642286055E1000F182B /* Pawn.swift */; };
+		C238564728608FA0000F182B /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238564628608FA0000F182B /* Piece.swift */; };
+		C238564828608FA0000F182B /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238564628608FA0000F182B /* Piece.swift */; };
+		C238564F28609A82000F182B /* GameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238564E28609A82000F182B /* GameManager.swift */; };
+		C238565028609A82000F182B /* GameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238564E28609A82000F182B /* GameManager.swift */; };
+		C23856522860AA93000F182B /* PieceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23856512860AA93000F182B /* PieceType.swift */; };
+		C23856532860AA93000F182B /* PieceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23856512860AA93000F182B /* PieceType.swift */; };
+		C23856552860AEE0000F182B /* Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23856542860AEE0000F182B /* Team.swift */; };
+		C23856562860AEE0000F182B /* Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23856542860AEE0000F182B /* Team.swift */; };
+		C23856582860AEF3000F182B /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23856572860AEF3000F182B /* Direction.swift */; };
+		C23856592860AEF3000F182B /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C23856572860AEF3000F182B /* Direction.swift */; };
+		C238565B2860AF19000F182B /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238565A2860AF19000F182B /* Point.swift */; };
+		C238565C2860AF19000F182B /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = C238565A2860AF19000F182B /* Point.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		C23856222860550F000F182B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C23856032860550E000F182B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C238560A2860550E000F182B;
+			remoteInfo = ChessGame;
+		};
+		C238562C28605510000F182B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C23856032860550E000F182B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C238560A2860550E000F182B;
+			remoteInfo = ChessGame;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		C238560B2860550E000F182B /* ChessGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C238560E2860550E000F182B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C23856102860550E000F182B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		C23856122860550E000F182B /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C23856152860550E000F182B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		C23856172860550F000F182B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C238561A2860550F000F182B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		C238561C2860550F000F182B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C23856212860550F000F182B /* ChessGameTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessGameTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C238562528605510000F182B /* ChessGameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameTests.swift; sourceTree = "<group>"; };
+		C238562B28605510000F182B /* ChessGameUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessGameUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C238562F28605510000F182B /* ChessGameUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameUITests.swift; sourceTree = "<group>"; };
+		C238563128605510000F182B /* ChessGameUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		C238563E286055A5000F182B /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
+		C2385642286055E1000F182B /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
+		C238564628608FA0000F182B /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
+		C238564E28609A82000F182B /* GameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManager.swift; sourceTree = "<group>"; };
+		C23856512860AA93000F182B /* PieceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceType.swift; sourceTree = "<group>"; };
+		C23856542860AEE0000F182B /* Team.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Team.swift; sourceTree = "<group>"; };
+		C23856572860AEF3000F182B /* Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Direction.swift; sourceTree = "<group>"; };
+		C238565A2860AF19000F182B /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		C23856082860550E000F182B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C238561E2860550F000F182B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C238562828605510000F182B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		C23856022860550E000F182B = {
+			isa = PBXGroup;
+			children = (
+				C238560D2860550E000F182B /* ChessGame */,
+				C23856242860550F000F182B /* ChessGameTests */,
+				C238562E28605510000F182B /* ChessGameUITests */,
+				C238560C2860550E000F182B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		C238560C2860550E000F182B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C238560B2860550E000F182B /* ChessGame.app */,
+				C23856212860550F000F182B /* ChessGameTests.xctest */,
+				C238562B28605510000F182B /* ChessGameUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C238560D2860550E000F182B /* ChessGame */ = {
+			isa = PBXGroup;
+			children = (
+				C23856492860911B000F182B /* Model */,
+				C238564E28609A82000F182B /* GameManager.swift */,
+				C238560E2860550E000F182B /* AppDelegate.swift */,
+				C23856102860550E000F182B /* SceneDelegate.swift */,
+				C23856122860550E000F182B /* ViewController.swift */,
+				C23856142860550E000F182B /* Main.storyboard */,
+				C23856172860550F000F182B /* Assets.xcassets */,
+				C23856192860550F000F182B /* LaunchScreen.storyboard */,
+				C238561C2860550F000F182B /* Info.plist */,
+			);
+			path = ChessGame;
+			sourceTree = "<group>";
+		};
+		C23856242860550F000F182B /* ChessGameTests */ = {
+			isa = PBXGroup;
+			children = (
+				C238562528605510000F182B /* ChessGameTests.swift */,
+			);
+			path = ChessGameTests;
+			sourceTree = "<group>";
+		};
+		C238562E28605510000F182B /* ChessGameUITests */ = {
+			isa = PBXGroup;
+			children = (
+				C238562F28605510000F182B /* ChessGameUITests.swift */,
+				C238563128605510000F182B /* ChessGameUITestsLaunchTests.swift */,
+			);
+			path = ChessGameUITests;
+			sourceTree = "<group>";
+		};
+		C23856492860911B000F182B /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				C238564A28609125000F182B /* Piece */,
+				C238563E286055A5000F182B /* Board.swift */,
+				C23856542860AEE0000F182B /* Team.swift */,
+				C23856572860AEF3000F182B /* Direction.swift */,
+				C238565A2860AF19000F182B /* Point.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		C238564A28609125000F182B /* Piece */ = {
+			isa = PBXGroup;
+			children = (
+				C238564628608FA0000F182B /* Piece.swift */,
+				C2385642286055E1000F182B /* Pawn.swift */,
+				C23856512860AA93000F182B /* PieceType.swift */,
+			);
+			path = Piece;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		C238560A2860550E000F182B /* ChessGame */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C238563528605510000F182B /* Build configuration list for PBXNativeTarget "ChessGame" */;
+			buildPhases = (
+				C23856072860550E000F182B /* Sources */,
+				C23856082860550E000F182B /* Frameworks */,
+				C23856092860550E000F182B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ChessGame;
+			productName = ChessGame;
+			productReference = C238560B2860550E000F182B /* ChessGame.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C23856202860550F000F182B /* ChessGameTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C238563828605510000F182B /* Build configuration list for PBXNativeTarget "ChessGameTests" */;
+			buildPhases = (
+				C238561D2860550F000F182B /* Sources */,
+				C238561E2860550F000F182B /* Frameworks */,
+				C238561F2860550F000F182B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C23856232860550F000F182B /* PBXTargetDependency */,
+			);
+			name = ChessGameTests;
+			productName = ChessGameTests;
+			productReference = C23856212860550F000F182B /* ChessGameTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		C238562A28605510000F182B /* ChessGameUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C238563B28605510000F182B /* Build configuration list for PBXNativeTarget "ChessGameUITests" */;
+			buildPhases = (
+				C238562728605510000F182B /* Sources */,
+				C238562828605510000F182B /* Frameworks */,
+				C238562928605510000F182B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C238562D28605510000F182B /* PBXTargetDependency */,
+			);
+			name = ChessGameUITests;
+			productName = ChessGameUITests;
+			productReference = C238562B28605510000F182B /* ChessGameUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		C23856032860550E000F182B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1340;
+				LastUpgradeCheck = 1340;
+				TargetAttributes = {
+					C238560A2860550E000F182B = {
+						CreatedOnToolsVersion = 13.4.1;
+					};
+					C23856202860550F000F182B = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = C238560A2860550E000F182B;
+					};
+					C238562A28605510000F182B = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = C238560A2860550E000F182B;
+					};
+				};
+			};
+			buildConfigurationList = C23856062860550E000F182B /* Build configuration list for PBXProject "ChessGame" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = C23856022860550E000F182B;
+			productRefGroup = C238560C2860550E000F182B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				C238560A2860550E000F182B /* ChessGame */,
+				C23856202860550F000F182B /* ChessGameTests */,
+				C238562A28605510000F182B /* ChessGameUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		C23856092860550E000F182B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C238561B2860550F000F182B /* LaunchScreen.storyboard in Resources */,
+				C23856182860550F000F182B /* Assets.xcassets in Resources */,
+				C23856162860550E000F182B /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C238561F2860550F000F182B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C238562928605510000F182B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		C23856072860550E000F182B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C23856552860AEE0000F182B /* Team.swift in Sources */,
+				C23856132860550E000F182B /* ViewController.swift in Sources */,
+				C238560F2860550E000F182B /* AppDelegate.swift in Sources */,
+				C23856582860AEF3000F182B /* Direction.swift in Sources */,
+				C23856522860AA93000F182B /* PieceType.swift in Sources */,
+				C238564728608FA0000F182B /* Piece.swift in Sources */,
+				C238564F28609A82000F182B /* GameManager.swift in Sources */,
+				C238565B2860AF19000F182B /* Point.swift in Sources */,
+				C238563F286055A5000F182B /* Board.swift in Sources */,
+				C2385643286055E1000F182B /* Pawn.swift in Sources */,
+				C23856112860550E000F182B /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C238561D2860550F000F182B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C238564828608FA0000F182B /* Piece.swift in Sources */,
+				C2385640286055A5000F182B /* Board.swift in Sources */,
+				C23856562860AEE0000F182B /* Team.swift in Sources */,
+				C23856592860AEF3000F182B /* Direction.swift in Sources */,
+				C2385644286055E1000F182B /* Pawn.swift in Sources */,
+				C238565C2860AF19000F182B /* Point.swift in Sources */,
+				C238562628605510000F182B /* ChessGameTests.swift in Sources */,
+				C23856532860AA93000F182B /* PieceType.swift in Sources */,
+				C238565028609A82000F182B /* GameManager.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C238562728605510000F182B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C238563028605510000F182B /* ChessGameUITests.swift in Sources */,
+				C238563228605510000F182B /* ChessGameUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		C23856232860550F000F182B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C238560A2860550E000F182B /* ChessGame */;
+			targetProxy = C23856222860550F000F182B /* PBXContainerItemProxy */;
+		};
+		C238562D28605510000F182B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C238560A2860550E000F182B /* ChessGame */;
+			targetProxy = C238562C28605510000F182B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		C23856142860550E000F182B /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C23856152860550E000F182B /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		C23856192860550F000F182B /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C238561A2860550F000F182B /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		C238563328605510000F182B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		C238563428605510000F182B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C238563628605510000F182B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChessGame/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kakao.ChessGame;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C238563728605510000F182B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ChessGame/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kakao.ChessGame;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		C238563928605510000F182B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kakao.ChessGameTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChessGame.app/ChessGame";
+			};
+			name = Debug;
+		};
+		C238563A28605510000F182B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kakao.ChessGameTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ChessGame.app/ChessGame";
+			};
+			name = Release;
+		};
+		C238563C28605510000F182B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kakao.ChessGameUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ChessGame;
+			};
+			name = Debug;
+		};
+		C238563D28605510000F182B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kakao.ChessGameUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ChessGame;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		C23856062860550E000F182B /* Build configuration list for PBXProject "ChessGame" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C238563328605510000F182B /* Debug */,
+				C238563428605510000F182B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C238563528605510000F182B /* Build configuration list for PBXNativeTarget "ChessGame" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C238563628605510000F182B /* Debug */,
+				C238563728605510000F182B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C238563828605510000F182B /* Build configuration list for PBXNativeTarget "ChessGameTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C238563928605510000F182B /* Debug */,
+				C238563A28605510000F182B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C238563B28605510000F182B /* Build configuration list for PBXNativeTarget "ChessGameUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C238563C28605510000F182B /* Debug */,
+				C238563D28605510000F182B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = C23856032860550E000F182B /* Project object */;
+}

--- a/ChessGame.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ChessGame.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ChessGame.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ChessGame.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ChessGame/AppDelegate.swift
+++ b/ChessGame/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/ChessGame/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ChessGame/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ChessGame/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ChessGame/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ChessGame/Assets.xcassets/Contents.json
+++ b/ChessGame/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ChessGame/Base.lproj/LaunchScreen.storyboard
+++ b/ChessGame/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ChessGame/Base.lproj/Main.storyboard
+++ b/ChessGame/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ChessGame/GameManager.swift
+++ b/ChessGame/GameManager.swift
@@ -1,0 +1,12 @@
+//
+//  GameManager.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import Foundation
+
+class GameManager {
+    
+}

--- a/ChessGame/Info.plist
+++ b/ChessGame/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ChessGame/Model/Board.swift
+++ b/ChessGame/Model/Board.swift
@@ -1,0 +1,41 @@
+//
+//  Board.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import Foundation
+
+class Board {
+    var pieces: [[Piece?]] = Array(repeating: Array(repeating: nil, count: 8), count: 8)
+    
+    init() {
+        reset()
+    }
+    
+    func reset() {
+        reset(team: .black)
+        reset(team: .white)
+    }
+    
+    func reset(team: Team) {
+        PieceType.allCases.forEach { type in 
+            type.initialPosition(team: team).forEach { point in
+                pieces[point.x][point.y] = Pawn(type: type, team: team) 
+            }
+        }
+    }
+    
+    func move() {
+        /// TODO: 
+    } 
+    
+    func score() {
+        /// TODO: 
+    }
+    
+    func display() {
+        /// TODO: 
+    }
+}

--- a/ChessGame/Model/Direction.swift
+++ b/ChessGame/Model/Direction.swift
@@ -1,0 +1,12 @@
+//
+//  Direction.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import Foundation
+
+enum Direction {
+    
+}

--- a/ChessGame/Model/Piece/Pawn.swift
+++ b/ChessGame/Model/Piece/Pawn.swift
@@ -1,0 +1,13 @@
+//
+//  Pawn.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import Foundation
+
+struct Pawn: Piece {
+    var type: PieceType
+    var team: Team
+}

--- a/ChessGame/Model/Piece/Piece.swift
+++ b/ChessGame/Model/Piece/Piece.swift
@@ -1,0 +1,13 @@
+//
+//  Piece.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import Foundation
+
+protocol Piece {
+    var type: PieceType { get set }
+    var team: Team { get set }
+}

--- a/ChessGame/Model/Piece/PieceType.swift
+++ b/ChessGame/Model/Piece/PieceType.swift
@@ -1,0 +1,64 @@
+//
+//  PieceType.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import Foundation
+
+enum PieceType: CaseIterable {
+    case pawn
+    case bishop
+    case knight
+    case luke
+    case queen
+    
+    var score: Int {
+        switch self {
+        case .pawn:
+            return 1
+        case .bishop:
+            return 3
+        case .knight:
+            return 3
+        case .luke:
+            return 5
+        case .queen:
+            return 9
+        }
+    }
+    
+    var limit: Int {
+        switch self {
+        case .pawn:
+            return 8
+        case .bishop:
+            return 2
+        case .knight:
+            return 2
+        case .luke:
+            return 2
+        case .queen:
+            return 1
+        }
+    }
+    
+    func shape(team: Team) -> String {
+        switch self {
+        case .pawn:
+            return team == .black ? "♞" : "♙"
+        default:
+            return "."
+        }
+    }
+    
+    func initialPosition(team: Team) -> [Point] {
+        switch self {
+        case .pawn:
+            return team == .black ? (0..<8).map { Point(x: 1, y: $0)} : (0..<8).map { Point(x: 7, y: $0)}
+        default:
+            return []
+        }
+    }
+}

--- a/ChessGame/Model/Point.swift
+++ b/ChessGame/Model/Point.swift
@@ -1,0 +1,13 @@
+//
+//  Point.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import Foundation
+
+struct Point {
+    var x: Int
+    var y: Int
+}

--- a/ChessGame/Model/Team.swift
+++ b/ChessGame/Model/Team.swift
@@ -1,0 +1,13 @@
+//
+//  Team.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import Foundation
+
+enum Team {
+    case black
+    case white
+}

--- a/ChessGame/SceneDelegate.swift
+++ b/ChessGame/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/ChessGame/ViewController.swift
+++ b/ChessGame/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  ChessGame
+//
+//  Created by celine on 2022/06/20.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/ChessGameTests/ChessGameTests.swift
+++ b/ChessGameTests/ChessGameTests.swift
@@ -1,0 +1,50 @@
+//
+//  ChessGameTests.swift
+//  ChessGameTests
+//
+//  Created by celine on 2022/06/20.
+//
+
+import XCTest
+@testable import ChessGame
+
+class ChessGameTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testPawn_initaliPosition() throws {
+        let board = Board()
+        board.reset()
+        
+        let row1 = board.pieces[1]
+        let row7 = board.pieces[7]
+        
+        row1.forEach { piece in
+            XCTAssertEqual(piece?.team, .black)
+            XCTAssertEqual(piece?.type, .pawn)
+        }
+        
+        row7.forEach { piece in
+            XCTAssertEqual(piece?.team, .white)
+            XCTAssertEqual(piece?.type, .pawn)
+        }
+    }
+    
+    func testPawn_limitNumber() throws {
+        let board = Board()
+        board.reset()
+        
+        let pawnCount = board.pieces
+            .flatMap { $0 }
+            .filter { $0?.type == .pawn }
+            .count
+        
+        XCTAssertEqual(PieceType.pawn.limit, pawnCount / 2)
+    }
+}

--- a/ChessGameUITests/ChessGameUITests.swift
+++ b/ChessGameUITests/ChessGameUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ChessGameUITests.swift
+//  ChessGameUITests
+//
+//  Created by celine on 2022/06/20.
+//
+
+import XCTest
+
+class ChessGameUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/ChessGameUITests/ChessGameUITestsLaunchTests.swift
+++ b/ChessGameUITests/ChessGameUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  ChessGameUITestsLaunchTests.swift
+//  ChessGameUITests
+//
+//  Created by celine on 2022/06/20.
+//
+
+import XCTest
+
+class ChessGameUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# swift-chessgame
-1-2주차 체스게임을 위한 저장소


### PR DESCRIPTION
# 설계
`Board`는 체스말에 대한 위치 정보를 갖고 있고, 각 말에 대한 정보는 `PieceType` enum에 정의를 하였습니다.
`Piece`에 대한 Model 정보는 프로토콜로 공통 프로퍼티를 만든 후 컨펌하게 하였습니다.

# 구현
현재는 `Board` 프로토타이핑과 체스말 `Pawn`이 구현이 되어있는 상태이고, 테스트는 `Pawn`의 개수 검사와 최초 위치를 테스트하였습니다.

# 고민
게임에 대한 진행 사항, 유효 체크를 `Board`가 아닌 `GameManager`라는 클래스에서 구현할지 고민이 됩니다. 