### PR TITLE
[Step1] Board, Pawn 객체 생성, 기초적인 메서드 및 테스트 생성

### DIFF
--- a/swift-chessgame/swift-chessgame.xcodeproj/project.pbxproj
+++ b/swift-chessgame/swift-chessgame.xcodeproj/project.pbxproj
@@ -1,0 +1,639 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		67B2383228605551008D7936 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2383128605551008D7936 /* AppDelegate.swift */; };
+		67B2383428605551008D7936 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2383328605551008D7936 /* SceneDelegate.swift */; };
+		67B2383628605551008D7936 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2383528605551008D7936 /* ViewController.swift */; };
+		67B2383928605551008D7936 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 67B2383728605551008D7936 /* Main.storyboard */; };
+		67B2383B28605551008D7936 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 67B2383A28605551008D7936 /* Assets.xcassets */; };
+		67B2383E28605551008D7936 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 67B2383C28605551008D7936 /* LaunchScreen.storyboard */; };
+		67B2384928605551008D7936 /* swift_chessgameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2384828605551008D7936 /* swift_chessgameTests.swift */; };
+		67B2385328605551008D7936 /* swift_chessgameUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2385228605551008D7936 /* swift_chessgameUITests.swift */; };
+		67B2385528605551008D7936 /* swift_chessgameUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2385428605551008D7936 /* swift_chessgameUITestsLaunchTests.swift */; };
+		67B23862286055DB008D7936 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B23861286055DB008D7936 /* Board.swift */; };
+		67B2387028606E2C008D7936 /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2386F28606E2C008D7936 /* Piece.swift */; };
+		67B2387228606E5F008D7936 /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2387128606E5F008D7936 /* Pawn.swift */; };
+		67B238822860B74F008D7936 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B238812860B74F008D7936 /* Coordinate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		67B2384528605551008D7936 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 67B2382628605551008D7936 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 67B2382D28605551008D7936;
+			remoteInfo = "swift-chessgame";
+		};
+		67B2384F28605551008D7936 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 67B2382628605551008D7936 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 67B2382D28605551008D7936;
+			remoteInfo = "swift-chessgame";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		67B2382E28605551008D7936 /* swift-chessgame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "swift-chessgame.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		67B2383128605551008D7936 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		67B2383328605551008D7936 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		67B2383528605551008D7936 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		67B2383828605551008D7936 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		67B2383A28605551008D7936 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		67B2383D28605551008D7936 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		67B2383F28605551008D7936 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		67B2384428605551008D7936 /* swift-chessgameTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "swift-chessgameTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		67B2384828605551008D7936 /* swift_chessgameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = swift_chessgameTests.swift; sourceTree = "<group>"; };
+		67B2384E28605551008D7936 /* swift-chessgameUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "swift-chessgameUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		67B2385228605551008D7936 /* swift_chessgameUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = swift_chessgameUITests.swift; sourceTree = "<group>"; };
+		67B2385428605551008D7936 /* swift_chessgameUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = swift_chessgameUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		67B23861286055DB008D7936 /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
+		67B2386F28606E2C008D7936 /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
+		67B2387128606E5F008D7936 /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
+		67B238812860B74F008D7936 /* Coordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinate.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		67B2382B28605551008D7936 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67B2384128605551008D7936 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67B2384B28605551008D7936 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		67B2382528605551008D7936 = {
+			isa = PBXGroup;
+			children = (
+				67B2383028605551008D7936 /* swift-chessgame */,
+				67B2384728605551008D7936 /* swift-chessgameTests */,
+				67B2385128605551008D7936 /* swift-chessgameUITests */,
+				67B2382F28605551008D7936 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		67B2382F28605551008D7936 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				67B2382E28605551008D7936 /* swift-chessgame.app */,
+				67B2384428605551008D7936 /* swift-chessgameTests.xctest */,
+				67B2384E28605551008D7936 /* swift-chessgameUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		67B2383028605551008D7936 /* swift-chessgame */ = {
+			isa = PBXGroup;
+			children = (
+				67B2383128605551008D7936 /* AppDelegate.swift */,
+				67B2383328605551008D7936 /* SceneDelegate.swift */,
+				67B2383528605551008D7936 /* ViewController.swift */,
+				67B23861286055DB008D7936 /* Board.swift */,
+				67B238802860B747008D7936 /* Common */,
+				67B2386728606D98008D7936 /* Piece */,
+				67B2383728605551008D7936 /* Main.storyboard */,
+				67B2383A28605551008D7936 /* Assets.xcassets */,
+				67B2383C28605551008D7936 /* LaunchScreen.storyboard */,
+				67B2383F28605551008D7936 /* Info.plist */,
+			);
+			path = "swift-chessgame";
+			sourceTree = "<group>";
+		};
+		67B2384728605551008D7936 /* swift-chessgameTests */ = {
+			isa = PBXGroup;
+			children = (
+				67B2384828605551008D7936 /* swift_chessgameTests.swift */,
+			);
+			path = "swift-chessgameTests";
+			sourceTree = "<group>";
+		};
+		67B2385128605551008D7936 /* swift-chessgameUITests */ = {
+			isa = PBXGroup;
+			children = (
+				67B2385228605551008D7936 /* swift_chessgameUITests.swift */,
+				67B2385428605551008D7936 /* swift_chessgameUITestsLaunchTests.swift */,
+			);
+			path = "swift-chessgameUITests";
+			sourceTree = "<group>";
+		};
+		67B2386728606D98008D7936 /* Piece */ = {
+			isa = PBXGroup;
+			children = (
+				67B2386F28606E2C008D7936 /* Piece.swift */,
+				67B2387128606E5F008D7936 /* Pawn.swift */,
+			);
+			path = Piece;
+			sourceTree = "<group>";
+		};
+		67B238802860B747008D7936 /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				67B238812860B74F008D7936 /* Coordinate.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		67B2382D28605551008D7936 /* swift-chessgame */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 67B2385828605551008D7936 /* Build configuration list for PBXNativeTarget "swift-chessgame" */;
+			buildPhases = (
+				67B2382A28605551008D7936 /* Sources */,
+				67B2382B28605551008D7936 /* Frameworks */,
+				67B2382C28605551008D7936 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "swift-chessgame";
+			productName = "swift-chessgame";
+			productReference = 67B2382E28605551008D7936 /* swift-chessgame.app */;
+			productType = "com.apple.product-type.application";
+		};
+		67B2384328605551008D7936 /* swift-chessgameTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 67B2385B28605551008D7936 /* Build configuration list for PBXNativeTarget "swift-chessgameTests" */;
+			buildPhases = (
+				67B2384028605551008D7936 /* Sources */,
+				67B2384128605551008D7936 /* Frameworks */,
+				67B2384228605551008D7936 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				67B2384628605551008D7936 /* PBXTargetDependency */,
+			);
+			name = "swift-chessgameTests";
+			productName = "swift-chessgameTests";
+			productReference = 67B2384428605551008D7936 /* swift-chessgameTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		67B2384D28605551008D7936 /* swift-chessgameUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 67B2385E28605551008D7936 /* Build configuration list for PBXNativeTarget "swift-chessgameUITests" */;
+			buildPhases = (
+				67B2384A28605551008D7936 /* Sources */,
+				67B2384B28605551008D7936 /* Frameworks */,
+				67B2384C28605551008D7936 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				67B2385028605551008D7936 /* PBXTargetDependency */,
+			);
+			name = "swift-chessgameUITests";
+			productName = "swift-chessgameUITests";
+			productReference = 67B2384E28605551008D7936 /* swift-chessgameUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		67B2382628605551008D7936 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1340;
+				LastUpgradeCheck = 1340;
+				TargetAttributes = {
+					67B2382D28605551008D7936 = {
+						CreatedOnToolsVersion = 13.4.1;
+					};
+					67B2384328605551008D7936 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = 67B2382D28605551008D7936;
+					};
+					67B2384D28605551008D7936 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = 67B2382D28605551008D7936;
+					};
+				};
+			};
+			buildConfigurationList = 67B2382928605551008D7936 /* Build configuration list for PBXProject "swift-chessgame" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 67B2382528605551008D7936;
+			productRefGroup = 67B2382F28605551008D7936 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				67B2382D28605551008D7936 /* swift-chessgame */,
+				67B2384328605551008D7936 /* swift-chessgameTests */,
+				67B2384D28605551008D7936 /* swift-chessgameUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		67B2382C28605551008D7936 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				67B2383E28605551008D7936 /* LaunchScreen.storyboard in Resources */,
+				67B2383B28605551008D7936 /* Assets.xcassets in Resources */,
+				67B2383928605551008D7936 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67B2384228605551008D7936 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67B2384C28605551008D7936 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		67B2382A28605551008D7936 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				67B238822860B74F008D7936 /* Coordinate.swift in Sources */,
+				67B2383628605551008D7936 /* ViewController.swift in Sources */,
+				67B2383228605551008D7936 /* AppDelegate.swift in Sources */,
+				67B2387228606E5F008D7936 /* Pawn.swift in Sources */,
+				67B2387028606E2C008D7936 /* Piece.swift in Sources */,
+				67B23862286055DB008D7936 /* Board.swift in Sources */,
+				67B2383428605551008D7936 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67B2384028605551008D7936 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				67B2384928605551008D7936 /* swift_chessgameTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		67B2384A28605551008D7936 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				67B2385328605551008D7936 /* swift_chessgameUITests.swift in Sources */,
+				67B2385528605551008D7936 /* swift_chessgameUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		67B2384628605551008D7936 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 67B2382D28605551008D7936 /* swift-chessgame */;
+			targetProxy = 67B2384528605551008D7936 /* PBXContainerItemProxy */;
+		};
+		67B2385028605551008D7936 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 67B2382D28605551008D7936 /* swift-chessgame */;
+			targetProxy = 67B2384F28605551008D7936 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		67B2383728605551008D7936 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				67B2383828605551008D7936 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		67B2383C28605551008D7936 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				67B2383D28605551008D7936 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		67B2385628605551008D7936 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		67B2385728605551008D7936 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		67B2385928605551008D7936 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = JYXBL43A2T;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "swift-chessgame/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "yoon.swift-chessgame";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		67B2385A28605551008D7936 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = JYXBL43A2T;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "swift-chessgame/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "yoon.swift-chessgame";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		67B2385C28605551008D7936 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = JYXBL43A2T;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "yoon.swift-chessgameTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/swift-chessgame.app/swift-chessgame";
+			};
+			name = Debug;
+		};
+		67B2385D28605551008D7936 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = JYXBL43A2T;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "yoon.swift-chessgameTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/swift-chessgame.app/swift-chessgame";
+			};
+			name = Release;
+		};
+		67B2385F28605551008D7936 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = JYXBL43A2T;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "yoon.swift-chessgameUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "swift-chessgame";
+			};
+			name = Debug;
+		};
+		67B2386028605551008D7936 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = JYXBL43A2T;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "yoon.swift-chessgameUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "swift-chessgame";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		67B2382928605551008D7936 /* Build configuration list for PBXProject "swift-chessgame" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67B2385628605551008D7936 /* Debug */,
+				67B2385728605551008D7936 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		67B2385828605551008D7936 /* Build configuration list for PBXNativeTarget "swift-chessgame" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67B2385928605551008D7936 /* Debug */,
+				67B2385A28605551008D7936 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		67B2385B28605551008D7936 /* Build configuration list for PBXNativeTarget "swift-chessgameTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67B2385C28605551008D7936 /* Debug */,
+				67B2385D28605551008D7936 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		67B2385E28605551008D7936 /* Build configuration list for PBXNativeTarget "swift-chessgameUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67B2385F28605551008D7936 /* Debug */,
+				67B2386028605551008D7936 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 67B2382628605551008D7936 /* Project object */;
+}

--- a/swift-chessgame/swift-chessgame.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/swift-chessgame/swift-chessgame.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/swift-chessgame/swift-chessgame.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/swift-chessgame/swift-chessgame.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/swift-chessgame/swift-chessgame/AppDelegate.swift
+++ b/swift-chessgame/swift-chessgame/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/swift-chessgame/swift-chessgame/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/swift-chessgame/swift-chessgame/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-chessgame/swift-chessgame/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/swift-chessgame/swift-chessgame/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,93 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-chessgame/swift-chessgame/Assets.xcassets/Contents.json
+++ b/swift-chessgame/swift-chessgame/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/swift-chessgame/swift-chessgame/Base.lproj/LaunchScreen.storyboard
+++ b/swift-chessgame/swift-chessgame/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/swift-chessgame/swift-chessgame/Base.lproj/Main.storyboard
+++ b/swift-chessgame/swift-chessgame/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/swift-chessgame/swift-chessgame/Board.swift
+++ b/swift-chessgame/swift-chessgame/Board.swift
@@ -1,0 +1,134 @@
+//
+//  Board.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import Foundation
+
+protocol BoardProtocol {
+    func initialize()
+    
+    // Requirement1 print current score
+    func printCurrentScore()
+    
+    // Requirement2 get current board state with String
+    func display() -> [String]
+    
+    // Requirement3 create piece on board at certain position
+    func create(_ piece: Piece, at position: Coordinate)
+    
+    // Requirement4 move piece on board
+    func move(fromPosition: Coordinate, toPosition: Coordinate) -> Bool
+}
+
+
+final class Board: BoardProtocol {
+    
+    private var boardInfo: [Coordinate : Piece] = [:]
+    
+    func initialize() {
+        Coordinate.files.forEach { file in
+            let position = Coordinate(rank: .one, file: file)
+            self.create(Pawn(color: .black), at: position)
+        }
+        
+        Coordinate.files.forEach { file in
+            let position = Coordinate(rank: .seven, file: file)
+            self.create(Pawn(color: .white), at: position)
+        }
+    }
+    
+    // MARK: - Requirement1 print current score
+    func printCurrentScore() {
+        let scores = calculateScore()
+        print(scores.black, scores.white)
+    }
+    
+    func calculateScore() -> (black: Int, white: Int) {
+        var blackScore: Int = 0
+        var whiteScore: Int = 0
+        
+        self.boardInfo.values.forEach { piece in
+            let score = piece.kind.score
+            if piece.color == .black {
+                blackScore += score
+            } else {
+                whiteScore += score
+            }
+        }
+        
+        return (blackScore, whiteScore)
+    }
+    
+    // MARK: - Requirement2 get current board state with String
+    func display() -> [String] {
+        var wholeDescription: [String] = []
+        Coordinate.ranks.forEach { rank in
+            var lineDescription = ""
+            Coordinate.files.forEach { file in
+                let coordinate = Coordinate(rank: rank, file: file)
+                let descripiton = boardInfo[coordinate]?.description ?? "."
+                lineDescription += descripiton
+            }
+            wholeDescription.append(lineDescription)
+        }
+        
+        return wholeDescription
+    }
+    
+    // MARK: - Requirement3 create piece on board at certain position
+    func create(_ piece: Piece, at position: Coordinate) {
+        boardInfo[position] = piece
+    }
+    
+    // MARK: - Requirement4 move piece on board
+    func move(fromPosition: Coordinate, toPosition: Coordinate) -> Bool {
+        guard let fromPiece = boardInfo[fromPosition] else {
+            return false
+        }
+        
+        let candidates = fromPiece.candidates(from: fromPosition)
+        if candidates.isEmpty || !candidates.contains(toPosition) {
+            return false
+        }
+    
+        let movePiece = {
+            self.boardInfo[fromPosition] = nil
+            self.boardInfo[toPosition] = fromPiece
+        }
+        
+        if let toPiece = boardInfo[toPosition] {
+            if fromPiece.color == toPiece.color {
+                return false
+            } else {
+                movePiece()
+            }
+        } else {
+            movePiece()
+        }
+        
+        return true
+    }
+}
+
+extension Board {
+    var pieces: [Piece] {
+        guard let pieces = Array(self.boardInfo.values) as? [Piece] else {
+            return []
+        }
+        return pieces
+    }
+    
+    var whitePieces: [Piece] {
+        self.pieces.filter { $0.color == .white }
+    }
+    
+    var blackPieces: [Piece] {
+        self.pieces.filter { $0.color == .black }
+    }
+}
+
+
+

--- a/swift-chessgame/swift-chessgame/Common/Coordinate.swift
+++ b/swift-chessgame/swift-chessgame/Common/Coordinate.swift
@@ -1,0 +1,53 @@
+//
+//  Coordinate.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import Foundation
+
+enum Direction {
+    case up
+    case down
+    case left
+    case right
+    
+    var unit: (rank: Int, file: Int) {
+        switch self {
+        case .up:    return (-1, 0)
+        case .down:  return (1, 0)
+        case .left:  return (0, -1)
+        case .right: return (0, 1)
+        }
+    }
+}
+
+struct Coordinate: Hashable {
+    static let ranks: [Rank] = Rank.allCases
+    static let files: [File] = File.allCases
+    
+    let rank: Rank
+    let file: File
+    
+    enum Rank: Int, CaseIterable {
+        case one = 1
+        case two, three, four, five, six, seven, eight
+    }
+
+    enum File: Int, CaseIterable {
+        case A = 1
+        case B, C, D, E, F, G, H
+    }
+
+    func move(count: Int, direction: Direction) -> Coordinate? {
+        let dRank = direction.unit.rank * count
+        let dFile = direction.unit.file * count
+        
+        guard let newRank = Rank(rawValue: self.rank.rawValue + dRank),
+              let newFile = File(rawValue: self.file.rawValue + dFile) else {
+            return nil
+        }
+        return Coordinate(rank: newRank, file: newFile)
+    }
+}

--- a/swift-chessgame/swift-chessgame/Info.plist
+++ b/swift-chessgame/swift-chessgame/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/swift-chessgame/swift-chessgame/Piece/Pawn.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Pawn.swift
@@ -1,0 +1,21 @@
+//
+//  Pawn.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import Foundation
+
+struct Pawn: Piece {
+    let color: PieceColor
+    let kind: PieceKind = .pawn
+    
+    func candidates(from position: Coordinate) -> [Coordinate] {
+        var candidates: [Coordinate] = []
+        if let candidate = position.move(count: 1, direction: self.direction) {
+            candidates.append(candidate)
+        }
+        return candidates
+    }
+}

--- a/swift-chessgame/swift-chessgame/Piece/Piece.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Piece.swift
@@ -1,0 +1,59 @@
+//
+//  Piece.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import Foundation
+
+enum PieceKind {
+    case pawn
+    
+    var score: Int {
+        switch self {
+        case .pawn: return 1
+        }
+    }
+    
+    var descriptions: (black: String, white: String) {
+        switch self {
+        case .pawn: return ("♟", "♙")
+        }
+    }
+    
+    var directions: (black: Direction, white: Direction) {
+        switch self {
+        case .pawn: return (.down, .up)
+        }
+    }
+
+}
+
+enum PieceColor {
+    case black, white
+}
+
+protocol Piece {
+    var color: PieceColor { get }
+    var kind: PieceKind { get }
+    
+    // Requirement7 piece provide movable position based on current position
+    func candidates(from position: Coordinate) -> [Coordinate]
+}
+
+extension Piece {
+    var description: String {
+        switch self.color {
+        case .black: return self.kind.descriptions.black
+        case .white: return self.kind.descriptions.white
+        }
+    }
+    
+    var direction: Direction {
+        switch self.color {
+        case .black: return self.kind.directions.black
+        case .white: return self.kind.directions.white
+        }
+    }
+}

--- a/swift-chessgame/swift-chessgame/SceneDelegate.swift
+++ b/swift-chessgame/swift-chessgame/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/swift-chessgame/swift-chessgame/ViewController.swift
+++ b/swift-chessgame/swift-chessgame/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/swift-chessgame/swift-chessgameTests/swift_chessgameTests.swift
+++ b/swift-chessgame/swift-chessgameTests/swift_chessgameTests.swift
@@ -1,0 +1,33 @@
+//
+//  swift_chessgameTests.swift
+//  swift-chessgameTests
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import XCTest
+@testable import swift_chessgame
+
+class BoardTests: XCTestCase {
+    func testBoard_initialize() {
+        let board = Board()
+        board.initialize()
+        
+        XCTAssertEqual(8, board.whitePieces.count)
+        XCTAssertEqual(8, board.blackPieces.count)
+        XCTAssertEqual(16, board.pieces.count)
+    }
+    
+    func testCalculate_score() {
+        let board = Board()
+        board.create(Pawn(color: .black), at: Coordinate(rank: .one, file: .A))
+        board.create(Pawn(color: .black), at: Coordinate(rank: .one, file: .B))
+        board.create(Pawn(color: .black), at: Coordinate(rank: .one, file: .C))
+        board.create(Pawn(color: .black), at: Coordinate(rank: .two, file: .A))
+        board.create(Pawn(color: .white), at: Coordinate(rank: .two, file: .B))
+        let results = board.calculateScore()
+        
+        XCTAssertEqual(4, results.black)
+        XCTAssertEqual(1, results.white)
+    }
+}

--- a/swift-chessgame/swift-chessgameUITests/swift_chessgameUITests.swift
+++ b/swift-chessgame/swift-chessgameUITests/swift_chessgameUITests.swift
@@ -1,0 +1,41 @@
+//
+//  swift_chessgameUITests.swift
+//  swift-chessgameUITests
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import XCTest
+
+class swift_chessgameUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/swift-chessgame/swift-chessgameUITests/swift_chessgameUITestsLaunchTests.swift
+++ b/swift-chessgame/swift-chessgameUITests/swift_chessgameUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  swift_chessgameUITestsLaunchTests.swift
+//  swift-chessgameUITests
+//
+//  Created by 이상윤 on 2022/06/20.
+//
+
+import XCTest
+
+class swift_chessgameUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/swift-chessgameTest.playground/Contents.swift
+++ b/swift-chessgameTest.playground/Contents.swift
@@ -1,0 +1,3 @@
+import UIKit
+
+var greeting = "Hello, playground"

--- a/swift-chessgameTest.playground/contents.xcplayground
+++ b/swift-chessgameTest.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='ios' buildActiveScheme='true' executeOnSourceChanges='false' importAppTypes='true'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>


### PR DESCRIPTION
## 해결과제

- Board, Pawn 객체 추가
- 기본적인 메서드 및 테스트 추가

## 설계의도와 방향
### Coordinate struct와 Direction enum
- 보드위의 좌표를 나타내기 위한 Coordinate struct를 추가했습니다
- Coordinate struct는 Int형의 rank file enum을 가지며 1부터 시작하는 값을 가집니다. 
  - 행과 열을 Int값을 가지는 enum으로 선언해서 범위를 벋어나는 좌표가 생성되는것을 막고 좌표이동게산을 rawValue값으로 쉽게 하려했습니다.
- Direction과 count를 받아 이동한 좌표의 값을 리턴하는 move메서드를 가집니다.

### Board
- Board가 구현해야하는 메서드 규약인 BoardProtocol을 채택합니다
- 내부 데이터수정이 빈번할것으로 예상되어 Class로 선언했습니다.
- BoardInfo라는 [Coordinate: Piece] 딕셔너리를 통해 각 피스의 위치를 관리합니다.

### Piece와 Pawn
- Piece 프로토콜은 color와 kind 그리고 현재 위치를 기준으로 갈수 있는 위치들을 리턴하는 candidates 메서드가 있습니다.
- 해당 piece의 고유한 특징(스코어,대표되는 문자정보,갈수있는방향) 등은 피스종류를 나타내는 enum PieceKind에 프로퍼티로 들어갑니다.
  - 고유한 특징값들은 한곳에서 관리하고자 했습니다.
  - 말의 종류가 추가되면 방향별 갈수 있는 카운트 정보도 추가될 예정입니다.
- Piece 프로토콜의 익스텐션으로 색에따라 달라지는값(대표되는 문자정보, 갈수있는 방향)들은 현재 Piece객체의 color정보를 이용해서 정확한 값을 얻을수있게 계산 프로퍼티를 추가했습니다.
- Pawn은 Piece 프로토콜을 채택하여 Struct로 선언되었습니다.

### Test
- 보드 초기화후 흰말과 검은 말의 갯수를 체크하는 테스트를 추가했습니다.
- 보드에 임의의 말을 넣었을때 계산한 점수가 맞는지 체크하는 테스트를 추가했습니다.
- 