### PR TITLE
[체스게임] [Step1] 보드 및 말 기본정의

### DIFF
--- a/Chessgame/Chessgame.xcodeproj/project.pbxproj
+++ b/Chessgame/Chessgame.xcodeproj/project.pbxproj
@@ -1,0 +1,582 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3E1DDABE28607A6100EFE990 /* ChessgameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDABD28607A6100EFE990 /* ChessgameApp.swift */; };
+		3E1DDAC028607A6100EFE990 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDABF28607A6100EFE990 /* ContentView.swift */; };
+		3E1DDAC228607A6200EFE990 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3E1DDAC128607A6200EFE990 /* Assets.xcassets */; };
+		3E1DDAC528607A6200EFE990 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3E1DDAC428607A6200EFE990 /* Preview Assets.xcassets */; };
+		3E1DDACF28607A6200EFE990 /* ChessgameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDACE28607A6200EFE990 /* ChessgameTests.swift */; };
+		3E1DDAD928607A6200EFE990 /* ChessgameUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDAD828607A6200EFE990 /* ChessgameUITests.swift */; };
+		3E1DDADB28607A6200EFE990 /* ChessgameUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDADA28607A6200EFE990 /* ChessgameUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		3E1DDACB28607A6200EFE990 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3E1DDAB228607A6100EFE990 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3E1DDAB928607A6100EFE990;
+			remoteInfo = Chessgame;
+		};
+		3E1DDAD528607A6200EFE990 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3E1DDAB228607A6100EFE990 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3E1DDAB928607A6100EFE990;
+			remoteInfo = Chessgame;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		3E1DDABA28607A6100EFE990 /* Chessgame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chessgame.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3E1DDABD28607A6100EFE990 /* ChessgameApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessgameApp.swift; sourceTree = "<group>"; };
+		3E1DDABF28607A6100EFE990 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		3E1DDAC128607A6200EFE990 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3E1DDAC428607A6200EFE990 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		3E1DDACA28607A6200EFE990 /* ChessgameTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessgameTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3E1DDACE28607A6200EFE990 /* ChessgameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessgameTests.swift; sourceTree = "<group>"; };
+		3E1DDAD428607A6200EFE990 /* ChessgameUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessgameUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3E1DDAD828607A6200EFE990 /* ChessgameUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessgameUITests.swift; sourceTree = "<group>"; };
+		3E1DDADA28607A6200EFE990 /* ChessgameUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessgameUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3E1DDAB728607A6100EFE990 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E1DDAC728607A6200EFE990 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E1DDAD128607A6200EFE990 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3E1DDAB128607A6100EFE990 = {
+			isa = PBXGroup;
+			children = (
+				3E1DDABC28607A6100EFE990 /* Chessgame */,
+				3E1DDACD28607A6200EFE990 /* ChessgameTests */,
+				3E1DDAD728607A6200EFE990 /* ChessgameUITests */,
+				3E1DDABB28607A6100EFE990 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3E1DDABB28607A6100EFE990 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3E1DDABA28607A6100EFE990 /* Chessgame.app */,
+				3E1DDACA28607A6200EFE990 /* ChessgameTests.xctest */,
+				3E1DDAD428607A6200EFE990 /* ChessgameUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3E1DDABC28607A6100EFE990 /* Chessgame */ = {
+			isa = PBXGroup;
+			children = (
+				3E1DDABD28607A6100EFE990 /* ChessgameApp.swift */,
+				3E1DDABF28607A6100EFE990 /* ContentView.swift */,
+				3E1DDAC128607A6200EFE990 /* Assets.xcassets */,
+				3E1DDAC328607A6200EFE990 /* Preview Content */,
+			);
+			path = Chessgame;
+			sourceTree = "<group>";
+		};
+		3E1DDAC328607A6200EFE990 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				3E1DDAC428607A6200EFE990 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		3E1DDACD28607A6200EFE990 /* ChessgameTests */ = {
+			isa = PBXGroup;
+			children = (
+				3E1DDACE28607A6200EFE990 /* ChessgameTests.swift */,
+			);
+			path = ChessgameTests;
+			sourceTree = "<group>";
+		};
+		3E1DDAD728607A6200EFE990 /* ChessgameUITests */ = {
+			isa = PBXGroup;
+			children = (
+				3E1DDAD828607A6200EFE990 /* ChessgameUITests.swift */,
+				3E1DDADA28607A6200EFE990 /* ChessgameUITestsLaunchTests.swift */,
+			);
+			path = ChessgameUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3E1DDAB928607A6100EFE990 /* Chessgame */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3E1DDADE28607A6200EFE990 /* Build configuration list for PBXNativeTarget "Chessgame" */;
+			buildPhases = (
+				3E1DDAB628607A6100EFE990 /* Sources */,
+				3E1DDAB728607A6100EFE990 /* Frameworks */,
+				3E1DDAB828607A6100EFE990 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Chessgame;
+			productName = Chessgame;
+			productReference = 3E1DDABA28607A6100EFE990 /* Chessgame.app */;
+			productType = "com.apple.product-type.application";
+		};
+		3E1DDAC928607A6200EFE990 /* ChessgameTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3E1DDAE128607A6200EFE990 /* Build configuration list for PBXNativeTarget "ChessgameTests" */;
+			buildPhases = (
+				3E1DDAC628607A6200EFE990 /* Sources */,
+				3E1DDAC728607A6200EFE990 /* Frameworks */,
+				3E1DDAC828607A6200EFE990 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3E1DDACC28607A6200EFE990 /* PBXTargetDependency */,
+			);
+			name = ChessgameTests;
+			productName = ChessgameTests;
+			productReference = 3E1DDACA28607A6200EFE990 /* ChessgameTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		3E1DDAD328607A6200EFE990 /* ChessgameUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3E1DDAE428607A6200EFE990 /* Build configuration list for PBXNativeTarget "ChessgameUITests" */;
+			buildPhases = (
+				3E1DDAD028607A6200EFE990 /* Sources */,
+				3E1DDAD128607A6200EFE990 /* Frameworks */,
+				3E1DDAD228607A6200EFE990 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3E1DDAD628607A6200EFE990 /* PBXTargetDependency */,
+			);
+			name = ChessgameUITests;
+			productName = ChessgameUITests;
+			productReference = 3E1DDAD428607A6200EFE990 /* ChessgameUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3E1DDAB228607A6100EFE990 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1340;
+				LastUpgradeCheck = 1340;
+				TargetAttributes = {
+					3E1DDAB928607A6100EFE990 = {
+						CreatedOnToolsVersion = 13.4.1;
+					};
+					3E1DDAC928607A6200EFE990 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = 3E1DDAB928607A6100EFE990;
+					};
+					3E1DDAD328607A6200EFE990 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = 3E1DDAB928607A6100EFE990;
+					};
+				};
+			};
+			buildConfigurationList = 3E1DDAB528607A6100EFE990 /* Build configuration list for PBXProject "Chessgame" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 3E1DDAB128607A6100EFE990;
+			productRefGroup = 3E1DDABB28607A6100EFE990 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3E1DDAB928607A6100EFE990 /* Chessgame */,
+				3E1DDAC928607A6200EFE990 /* ChessgameTests */,
+				3E1DDAD328607A6200EFE990 /* ChessgameUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3E1DDAB828607A6100EFE990 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E1DDAC528607A6200EFE990 /* Preview Assets.xcassets in Resources */,
+				3E1DDAC228607A6200EFE990 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E1DDAC828607A6200EFE990 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E1DDAD228607A6200EFE990 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3E1DDAB628607A6100EFE990 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E1DDAC028607A6100EFE990 /* ContentView.swift in Sources */,
+				3E1DDABE28607A6100EFE990 /* ChessgameApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E1DDAC628607A6200EFE990 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E1DDACF28607A6200EFE990 /* ChessgameTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3E1DDAD028607A6200EFE990 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3E1DDAD928607A6200EFE990 /* ChessgameUITests.swift in Sources */,
+				3E1DDADB28607A6200EFE990 /* ChessgameUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		3E1DDACC28607A6200EFE990 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3E1DDAB928607A6100EFE990 /* Chessgame */;
+			targetProxy = 3E1DDACB28607A6200EFE990 /* PBXContainerItemProxy */;
+		};
+		3E1DDAD628607A6200EFE990 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3E1DDAB928607A6100EFE990 /* Chessgame */;
+			targetProxy = 3E1DDAD528607A6200EFE990 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		3E1DDADC28607A6200EFE990 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		3E1DDADD28607A6200EFE990 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		3E1DDADF28607A6200EFE990 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Chessgame/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yeolmaecode.Chessgame;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		3E1DDAE028607A6200EFE990 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Chessgame/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yeolmaecode.Chessgame;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		3E1DDAE228607A6200EFE990 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yeolmaecode.ChessgameTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Chessgame.app/Chessgame";
+			};
+			name = Debug;
+		};
+		3E1DDAE328607A6200EFE990 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yeolmaecode.ChessgameTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Chessgame.app/Chessgame";
+			};
+			name = Release;
+		};
+		3E1DDAE528607A6200EFE990 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yeolmaecode.ChessgameUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Chessgame;
+			};
+			name = Debug;
+		};
+		3E1DDAE628607A6200EFE990 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yeolmaecode.ChessgameUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Chessgame;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3E1DDAB528607A6100EFE990 /* Build configuration list for PBXProject "Chessgame" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3E1DDADC28607A6200EFE990 /* Debug */,
+				3E1DDADD28607A6200EFE990 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3E1DDADE28607A6200EFE990 /* Build configuration list for PBXNativeTarget "Chessgame" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3E1DDADF28607A6200EFE990 /* Debug */,
+				3E1DDAE028607A6200EFE990 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3E1DDAE128607A6200EFE990 /* Build configuration list for PBXNativeTarget "ChessgameTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3E1DDAE228607A6200EFE990 /* Debug */,
+				3E1DDAE328607A6200EFE990 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3E1DDAE428607A6200EFE990 /* Build configuration list for PBXNativeTarget "ChessgameUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3E1DDAE528607A6200EFE990 /* Debug */,
+				3E1DDAE628607A6200EFE990 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3E1DDAB228607A6100EFE990 /* Project object */;
+}

--- a/Chessgame/Chessgame.xcodeproj/project.pbxproj
+++ b/Chessgame/Chessgame.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		3E1DDACF28607A6200EFE990 /* ChessgameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDACE28607A6200EFE990 /* ChessgameTests.swift */; };
 		3E1DDAD928607A6200EFE990 /* ChessgameUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDAD828607A6200EFE990 /* ChessgameUITests.swift */; };
 		3E1DDADB28607A6200EFE990 /* ChessgameUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDADA28607A6200EFE990 /* ChessgameUITestsLaunchTests.swift */; };
+		3E1DDAEA2860824800EFE990 /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDAE92860824800EFE990 /* Piece.swift */; };
+		3E1DDAEC286082D900EFE990 /* PieceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDAEB286082D900EFE990 /* PieceType.swift */; };
+		3E1DDAEE286084A300EFE990 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1DDAED286084A300EFE990 /* Board.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +47,9 @@
 		3E1DDAD428607A6200EFE990 /* ChessgameUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessgameUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E1DDAD828607A6200EFE990 /* ChessgameUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessgameUITests.swift; sourceTree = "<group>"; };
 		3E1DDADA28607A6200EFE990 /* ChessgameUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessgameUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		3E1DDAE92860824800EFE990 /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
+		3E1DDAEB286082D900EFE990 /* PieceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceType.swift; sourceTree = "<group>"; };
+		3E1DDAED286084A300EFE990 /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +102,9 @@
 			children = (
 				3E1DDABD28607A6100EFE990 /* ChessgameApp.swift */,
 				3E1DDABF28607A6100EFE990 /* ContentView.swift */,
+				3E1DDAED286084A300EFE990 /* Board.swift */,
+				3E1DDAE92860824800EFE990 /* Piece.swift */,
+				3E1DDAEB286082D900EFE990 /* PieceType.swift */,
 				3E1DDAC128607A6200EFE990 /* Assets.xcassets */,
 				3E1DDAC328607A6200EFE990 /* Preview Content */,
 			);
@@ -259,6 +268,9 @@
 			files = (
 				3E1DDAC028607A6100EFE990 /* ContentView.swift in Sources */,
 				3E1DDABE28607A6100EFE990 /* ChessgameApp.swift in Sources */,
+				3E1DDAEE286084A300EFE990 /* Board.swift in Sources */,
+				3E1DDAEC286082D900EFE990 /* PieceType.swift in Sources */,
+				3E1DDAEA2860824800EFE990 /* Piece.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Chessgame/Chessgame.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Chessgame/Chessgame.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Chessgame/Chessgame.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Chessgame/Chessgame.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Chessgame/Chessgame/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Chessgame/Chessgame/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Chessgame/Chessgame/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Chessgame/Chessgame/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Chessgame/Chessgame/Assets.xcassets/Contents.json
+++ b/Chessgame/Chessgame/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Chessgame/Chessgame/Board.swift
+++ b/Chessgame/Chessgame/Board.swift
@@ -1,0 +1,27 @@
+//
+//  Board.swift
+//  Chessgame
+//
+//  Created by faker on 2022/06/20.
+//
+
+import Foundation
+
+class Board {
+    
+    let chessboard = [[Piece?]](repeating: [Piece?](repeating: nil, count: 8), count: 8)
+
+}
+
+/*
+ABCDEFGH
+1♜♞♝.♛♝♞♜
+2♟♟♟♟♟♟♟♟
+3........
+4........
+5........
+6........
+7♙♙♙♙♙♙♙♙
+8♖♘♗.♕♗♘♖
+ABCDEFGH
+*/

--- a/Chessgame/Chessgame/ChessgameApp.swift
+++ b/Chessgame/Chessgame/ChessgameApp.swift
@@ -1,0 +1,17 @@
+//
+//  ChessgameApp.swift
+//  Chessgame
+//
+//  Created by yeolmaecode on 2022/06/20.
+//
+
+import SwiftUI
+
+@main
+struct ChessgameApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Chessgame/Chessgame/ContentView.swift
+++ b/Chessgame/Chessgame/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  Chessgame
+//
+//  Created by yeolmaecode on 2022/06/20.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Chessgame/Chessgame/ContentView.swift
+++ b/Chessgame/Chessgame/ContentView.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 
 struct ContentView: View {
+    
+    let chessboard = Board()
+    
     var body: some View {
         Text("Hello, world!")
             .padding()

--- a/Chessgame/Chessgame/Piece.swift
+++ b/Chessgame/Chessgame/Piece.swift
@@ -1,0 +1,34 @@
+//
+//  Piece.swift
+//  Chessgame
+//
+//  Created by faker on 2022/06/20.
+//
+
+import Foundation
+
+protocol PieceProtocol
+{
+    func move()
+    func die()
+}
+
+class Piece: PieceProtocol {
+
+    var type: PieceType
+    var color: PieceColor
+    
+    func move() {
+        print("말이동")
+    }
+    
+    func die() {
+        print("말죽음")
+    }
+    
+    init(type: PieceType, color: PieceColor) {
+        self.type = type
+        self.color = color
+    }
+
+}

--- a/Chessgame/Chessgame/PieceType.swift
+++ b/Chessgame/Chessgame/PieceType.swift
@@ -1,0 +1,22 @@
+//
+//  PieceType.swift
+//  Chessgame
+//
+//  Created by faker on 2022/06/20.
+//
+
+import Foundation
+
+enum PieceType {
+    case king
+    case queen
+    case rook
+    case bishop
+    case knight
+    case pawn
+}
+
+enum PieceColor {
+    case black
+    case white
+}

--- a/Chessgame/Chessgame/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Chessgame/Chessgame/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Chessgame/ChessgameTests/ChessgameTests.swift
+++ b/Chessgame/ChessgameTests/ChessgameTests.swift
@@ -1,0 +1,36 @@
+//
+//  ChessgameTests.swift
+//  ChessgameTests
+//
+//  Created by yeolmaecode on 2022/06/20.
+//
+
+import XCTest
+@testable import Chessgame
+
+class ChessgameTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Chessgame/ChessgameTests/ChessgameTests.swift
+++ b/Chessgame/ChessgameTests/ChessgameTests.swift
@@ -24,6 +24,10 @@ class ChessgameTests: XCTestCase {
         // Any test you write for XCTest can be annotated as throws and async.
         // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
         // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+        let board = Board()
+        print("보드크기는 \(board.chessboard.count) \(board.chessboard)")
+        let qeen = Piece(type: .queen, color: .white)
+        let king = Piece(type: .king, color: .white)
     }
 
     func testPerformanceExample() throws {

--- a/Chessgame/ChessgameUITests/ChessgameUITests.swift
+++ b/Chessgame/ChessgameUITests/ChessgameUITests.swift
@@ -1,0 +1,41 @@
+//
+//  ChessgameUITests.swift
+//  ChessgameUITests
+//
+//  Created by yeolmaecode on 2022/06/20.
+//
+
+import XCTest
+
+class ChessgameUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/Chessgame/ChessgameUITests/ChessgameUITestsLaunchTests.swift
+++ b/Chessgame/ChessgameUITests/ChessgameUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  ChessgameUITestsLaunchTests.swift
+//  ChessgameUITests
+//
+//  Created by yeolmaecode on 2022/06/20.
+//
+
+import XCTest
+
+class ChessgameUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
질문. 1 프로그램을 시작하면 King을 제외한 흑/백 체스말을 초기화한다.
	- 왜 킹은 초기화에서 제외가 되나요?

고민거리
	ㅇ 기능요구사항과 프로그래밍 요구사항 동시에 진행하면 될지?
	ㅇ 각좌표별로 입력받고 이동시켜야하는대 어떻게 구현해야할지?
	ㅇ 말 (piece)들의 타입은 같으나 각 요구사항별로 다르게 움직이게 구현해야할지?
	ㅇ 말이 잡히면 어떻게 처리할지?
	ㅇ 유닛테스는 어떻게 해야할지?
	
Step 1
- 보드판 생성
- 말 타입 및 색상 정의

**과제를 내가 보기편하게 다시 정리**

기능요구사항정리
	ㅇ 말초기화
		 - 프로그램을 시작하면 King을 제외한 흑/백 체스말을 초기화한다
	ㅇ 현재 누가 턴인지에 대한상태값 
		 - 프로그램을 동작하는 동안, 턴을 반복하면서 입력을 받아서 말을 움직인다
		 - 체스말을 이동하는 명령은 백색부터 시작해서, 흑과 백이 번갈아서 처리해야 한다.
	ㅇ 말에 따른 이동 방식 정의 
		 - 말이 있는 위치 2자리 문자와 이동하려는 위치 2자리 문자를 입력받는다. 형식에 맞지 않으면 다시 입력받는다.
	ㅇ 점수판 기능 
		 - 흑 또는 백 체스말이 상대편 말이 있던 곳으로 이동해서 상대편 말을 잡는 경우는 체스판 점수를 출력한다.
	ㅇ 도움말 기능
		 - 도움말 기능은 특정 위치에 있는 말이 움직일 수 있는 경우를 모두 출력한다.
		 - 단, 자신과 같은 색의 말이 가리고 있는 경우는 멈춘다.
		 - 예시) A1에 흑색 Luke가 있고, C1에 흑색 Bishop이 있는 경우 : "A2,A3,A4,A5,A6,A7,A8,B1"
		 - 예시) F1에 흑색 Bishop이 있고, E2와 G2에 Pawn이 있는 경우 : "없음"

프로그래밍 요구사항 (Board)
	ㅇ Board는 8x8 (가로 rank x 세로 file) 크기 체스판에 체스말(Piece) 존재 여부를 관리한다.
	ㅇ Board는 현재 있는 말을 확인해서 흑과 백 점수를 출력한다.
		- 색상별로 Pawn 1점, Bishop와 Knight 3점, Luke 5점, 퀸은 9점으로 계산한다.
	ㅇ Board는 모든 말의 위치를 알 수 있고, display() 함수는 1-rank부터 8-rank까지 rank 문자열 배열로 보드 위에 체스말을 리턴한다
		- 흑색 Pawn는 ♟ U+265F, Knight는 ♞ U+265E, Biship은 ♝ U+265D, Luke는 ♜ U+265C, Queen은 ♛ U+265B를 빈 곳은 "."을 표시한다.
		- 백색 Pawn는 ♙ U+2659, Knight는 ♘ U+2658, Biship은 ♗ U+2657, Luke는 ♖ U+2656, Queen은 ♕ U+2655를 빈 곳은 "."을 표시한다.
		- 예를 들어 초기화 상태에 Luke, Bishop, Queen만 있는 경우 1-rank는 "♜♞♝.♛♝♞♜" 가 된다.
	ㅇ 특정 위치에 특정 말을 생성한다.
		- 초기화할 때 1,2-rank는 흑백 체스말이, 7,8-rank는 백색 체스말이 위치한다.
		- 체스말 초기 위치가 아니면 생성하지 않는다.
		- 이미 해당 위치에 다른 말이 있으면 생성하지 않는다.
		- 체스말 종류별로 최대 개수보다 많이 생성할 수는 없다.
		- Pawn는 색상별로 8개. Bishop, Luke는 색상별로 2개, Queen는 색상별로 1개만 가능하다.
	ㅇ 특정 위치에 특정 말을 생성한다.
		- 같은 색상의 말이 to 위치에 다른 말이 이미 있으면 옮길 수 없다.
		- 말을 옮길 수 있으면 true, 옮길 수 없으면 false를 리턴한다
		- 만약, 다른 색상의 말이 to 위치에 있는 경우는 기존에 있던 말을 제거하고 이동한다.
	ㅇ 체스말은 위치값은 가로 file은 A부터 H까지, 세로 rank는 1부터 8까지 입력이 가능하다.
	ㅇ 체스말은 색상값을 흑Black 또는 백White 중에 하나를 가진다.
		- 체스말 색상은 변경할 수 없다.
	ㅇ 체스말은 현재 위치를 기준으로 이동할 수 있는 모든 위치를 제공한다.
		- 다른 말이 있는지 여부는 판단하지 않는다

프로그래밍 요구사항 말 (Piece)
	ㅇ Pawn 요구사항
		- 생성 위치는 흑색은 2-rank 또는 백색 7-rank에만 가능하다.
		- 백색은 더 작은 rank로 움직일 수 있고, 흑색은 더 큰 rank로 움직일 수 있다.
		- 체스 게임과 달리 처음에도 1칸만 움직일 수 있고, 다른 말을 잡을 때도 대각선이 아니라 직선으로 움직일 때 잡는다고 가정한다.
	ㅇ Bishop 요구사항
		- 생성 위치는 흑색은 C-1 과 F-1 에만 가능하고, 백색은 C-8 과 F-8 에만 가능하다.
		- 모든 색상이 놓여진 칸을 기준으로 대각선으로만 움직일 수 있다.
	ㅇ Bishop 요구사항
		- 생성 위치는 흑색은 A-1 과 H-1 에만 가능하고, 백색은 A-8 과 H-8 에만 가능하다.
		- 모든 색상이 놓여진 칸을 기준으로 좌-우 또는 위-아래 방향으로 움직일 수 있다.
	ㅇ Queen 요구사항
		- 생성 위치는 흑색은 E-1에만 가능하고, 백색은 E-8 에만 가능하다.
	ㅇ Knight 요구사항
		- 생성 위치는 흑색은 B-1 과 G-1 에만 가능하고, 백색은 B-8 과 G-8 에만 가능하다.
		- 모든 색상이 놓여진 칸을 기준으로 전진1칸+대각선1칸으로만 움직일 수 있다.
		- 체스 게임과 달리 전진하는 칸이 막혀있으면 움직일 수 없다.