### PR TITLE
Feature step 1 추가 구현

### DIFF
--- a/Chess/Chess.xcodeproj/project.pbxproj
+++ b/Chess/Chess.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C2360C782860748B00E117C9 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360C762860748B00E117C9 /* Board.swift */; };
 		C2360C792860748B00E117C9 /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360C772860748B00E117C9 /* Piece.swift */; };
 		C2360C7B28615EA300E117C9 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360C7A28615EA300E117C9 /* Position.swift */; };
+		C2360CAD2865A68700E117C9 /* PieceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360CAC2865A68700E117C9 /* PieceRule.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		C2360C762860748B00E117C9 /* Board.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		C2360C772860748B00E117C9 /* Piece.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
 		C2360C7A28615EA300E117C9 /* Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
+		C2360CAC2865A68700E117C9 /* PieceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceRule.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 				C2360C492860744500E117C9 /* ViewController.swift */,
 				C2360C762860748B00E117C9 /* Board.swift */,
 				C2360C772860748B00E117C9 /* Piece.swift */,
+				C2360CAC2865A68700E117C9 /* PieceRule.swift */,
 				C2360C7A28615EA300E117C9 /* Position.swift */,
 				C2360C4B2860744500E117C9 /* Main.storyboard */,
 			);
@@ -279,6 +282,7 @@
 				C2360C462860744500E117C9 /* AppDelegate.swift in Sources */,
 				C2360C7B28615EA300E117C9 /* Position.swift in Sources */,
 				C2360C792860748B00E117C9 /* Piece.swift in Sources */,
+				C2360CAD2865A68700E117C9 /* PieceRule.swift in Sources */,
 				C2360C782860748B00E117C9 /* Board.swift in Sources */,
 				C2360C482860744500E117C9 /* SceneDelegate.swift in Sources */,
 			);

--- a/Chess/Chess/Board.swift
+++ b/Chess/Chess/Board.swift
@@ -20,13 +20,13 @@ final class Board {
             var types: [PieceType?]?
             var color: PieceColor?
             
-            if rank == .A || rank == .H {
-                types = [.luke, .knight, .biship, nil, .queen, .biship, .knight, .luke]
-                color = rank == .A ? .black : .white
+            if rank == ._1 || rank == ._8 {
+                types = [.luke, .knight, .bishop, nil, .queen, .bishop, .knight, .luke]
+                color = rank == ._1 ? .black : .white
                 
-            } else if rank == .B || rank == .G {
+            } else if rank == ._2 || rank == ._7 {
                 types = [.pawn, .pawn, .pawn, .pawn, .pawn, .pawn, .pawn, .pawn]
-                color = rank == .B ? .black : .white
+                color = rank == ._2 ? .black : .white
             }
             
             if let types = types, let color = color {
@@ -40,7 +40,7 @@ final class Board {
         
         for (index, type) in types.enumerated() {
             if let file = BoardFile(rawValue: index), let type = type {
-                pieces[index] = ChessPiece(color: color, type: type, position: Position(rank: rank, file: file))
+                pieces[index] = ChessPiece(color: color, type: type, position: Position(file: file, rank: rank))
             }
         }
         
@@ -74,7 +74,7 @@ final class Board {
     func movePiece(from target: Position, to dest: Position) -> Bool {
         guard let targetPiece = piecePosition[target] else { return false }
         
-        let movablePositions = targetPiece.movablePositions.filter { position in
+        let movablePositions = targetPiece.rule.movablePositions(current: target).filter { position in
             let destPiece = piecePosition[position]
             
             return destPiece?.color != targetPiece.color

--- a/Chess/Chess/Piece.swift
+++ b/Chess/Chess/Piece.swift
@@ -7,6 +7,14 @@
 
 import Foundation
 
+enum PieceColor {
+    case white, black
+}
+
+enum PieceType {
+    case pawn, knight, bishop, luke, queen
+}
+
 protocol Piece {
     var color: PieceColor { get set }
     var type: PieceType { get set }
@@ -15,15 +23,7 @@ protocol Piece {
     var max: Int { get }
     var score: Int { get }
     var icon: String { get }
-    var movablePositions: [Position] { get }
-}
-
-enum PieceColor {
-    case white, black
-}
-
-enum PieceType {
-    case pawn, knight, biship, luke, queen
+    var rule: PieceRule { get }
 }
 
 struct ChessPiece: Piece {
@@ -34,7 +34,7 @@ struct ChessPiece: Piece {
     var max: Int {
         switch type {
         case .pawn:                     return 8
-        case .biship, .luke, .knight:   return 2
+        case .bishop, .luke, .knight:   return 2
         case .queen:                    return 1
         }
     }
@@ -42,7 +42,7 @@ struct ChessPiece: Piece {
     var score: Int {
         switch type {
         case .pawn:             return 1
-        case .biship, .knight:  return 3
+        case .bishop, .knight:  return 3
         case .luke:             return 5
         case .queen:            return 9
         }
@@ -54,7 +54,7 @@ struct ChessPiece: Piece {
             switch type {
             case .pawn:     return "\u{2659}"
             case .knight:   return "\u{2658}"
-            case .biship:   return "\u{2657}"
+            case .bishop:   return "\u{2657}"
             case .luke:     return "\u{2656}"
             case .queen:    return "\u{2655}"
             }
@@ -62,40 +62,20 @@ struct ChessPiece: Piece {
             switch type {
             case .pawn:     return "\u{265F}"
             case .knight:   return "\u{265E}"
-            case .biship:   return "\u{265D}"
+            case .bishop:   return "\u{265D}"
             case .luke:     return "\u{265C}"
             case .queen:    return "\u{265B}"
             }
         }
     }
     
-    var movablePositions: [Position] {
+    var rule: PieceRule {
         switch type {
-        case .pawn:
-            switch color {
-            case .white:
-                let nextRankRaw = position.rank.rawValue - 1
-                
-                if BoardRank.A.rawValue <= nextRankRaw, let nextRank = BoardRank(rawValue: nextRankRaw) {
-                    return [Position(rank: nextRank, file: position.file)]
-                }
-            case .black:
-                let nextRankRaw = position.rank.rawValue + 1
-                
-                if BoardRank.H.rawValue >= nextRankRaw, let nextRank = BoardRank(rawValue: nextRankRaw) {
-                    return [Position(rank: nextRank, file: position.file)]
-                }
-            }
-        case .knight:
-            break
-        case .biship:
-            break
-        case .luke:
-            break
-        case .queen:
-            break
+        case .pawn:     return PawnRule(color: color)
+        case .knight:   return KnightRule(color: color)
+        case .bishop:   return BishopRule(color: color)
+        case .luke:     return LukeRule(color: color)
+        case .queen:    return QueenRule(color: color)
         }
-        
-        return []
     }
 }

--- a/Chess/Chess/PieceRule.swift
+++ b/Chess/Chess/PieceRule.swift
@@ -1,0 +1,197 @@
+//
+//  PieceRule.swift
+//  Chess
+//
+//  Created by kakao on 2022/06/24.
+//
+
+import Foundation
+
+protocol PieceRule {
+    var color: PieceColor { get }
+    
+    func movablePositions(current: Position) -> [Position]
+}
+
+extension PieceRule {
+    fileprivate func leftPositions(current: Position) -> [Position] {
+        let leftCount = current.file.rawValue - BoardFile.A.rawValue
+        
+        if leftCount == 0 {
+            return []
+        }
+        
+        return (1...leftCount).compactMap({
+            guard let file = BoardFile(rawValue: current.file.rawValue - $0) else { return nil }
+                
+            return Position(file: file, rank: current.rank)
+        })
+    }
+    
+    fileprivate func leftTopPositions(current: Position) -> [Position] {
+        let left = leftPositions(current: current)
+        let top = topPositions(current: current)
+        
+        return zip(left, top).compactMap({ Position(file: $0.file, rank: $1.rank) })
+    }
+    
+    fileprivate func topPositions(current: Position) -> [Position] {
+        let topCount = current.rank.rawValue - BoardRank._1.rawValue
+        
+        if topCount == 0 {
+            return []
+        }
+        
+        return (1...topCount).compactMap({
+            guard let rank = BoardRank(rawValue: current.rank.rawValue - $0) else { return nil }
+            
+            return Position(file: current.file, rank: rank)
+        })
+    }
+    
+    fileprivate func rightTopPositions(current: Position) -> [Position] {
+        let right = rightPositions(current: current)
+        let top = topPositions(current: current)
+        
+        return zip(right, top).compactMap({ Position(file: $0.file, rank: $1.rank) })
+    }
+    
+    fileprivate func rightPositions(current: Position) -> [Position] {
+        let rightCount = BoardFile.H.rawValue - current.file.rawValue
+        
+        if rightCount == 0 {
+            return []
+        }
+        
+        return (1...rightCount).compactMap({
+            guard let file = BoardFile(rawValue: current.file.rawValue + $0) else { return nil }
+                    
+            return Position(file: file, rank: current.rank)
+        })
+    }
+    
+    fileprivate func rightBottomPositions(current: Position) -> [Position] {
+        let right = rightPositions(current: current)
+        let bottom = bottomPositions(current: current)
+        
+        return zip(right, bottom).compactMap({ Position(file: $0.file, rank: $1.rank) })
+    }
+    
+    fileprivate func bottomPositions(current: Position) -> [Position] {
+        let bottomCount = BoardRank._8.rawValue - current.rank.rawValue
+        
+        if bottomCount == 0 {
+            return []
+        }
+        
+        return (1...bottomCount).compactMap({
+            guard let rank = BoardRank(rawValue: current.rank.rawValue + $0) else { return nil }
+            
+            return Position(file: current.file, rank: rank)
+        })
+    }
+    
+    fileprivate func leftBottomPositions(current: Position) -> [Position] {
+        let left = leftPositions(current: current)
+        let bottom = bottomPositions(current: current)
+        
+        return zip(left, bottom).compactMap({ Position(file: $0.file, rank: $1.rank) })
+    }
+}
+
+struct PawnRule: PieceRule {
+    var color: PieceColor
+    
+    func movablePositions(current: Position) -> [Position] {
+        var newPosition = current
+        var nextRank: BoardRank?
+        
+        switch color {
+        case .white:
+            nextRank = current.rank - 1
+        case .black:
+            nextRank = current.rank + 1
+        }
+        
+        if let nextRank = nextRank {
+            newPosition.rank = nextRank
+            return [newPosition]
+        } else {
+            return []
+        }
+    }
+}
+
+struct KnightRule: PieceRule {
+    var color: PieceColor
+    
+    func movablePositions(current: Position) -> [Position] {
+        var positions: [Position] = []
+        var nextRank: BoardRank?
+        
+        switch color {
+        case .white:
+            nextRank = current.rank - 1
+        case .black:
+            nextRank = current.rank + 1
+        }
+        
+        if let nextRank = nextRank {
+            if let leftFile = current.file - 1 {
+                positions.append(Position(file: leftFile, rank: nextRank))
+            }
+            
+            if let rightFile = current.file + 1 {
+                positions.append(Position(file: rightFile, rank: nextRank))
+            }
+            
+            return positions
+        } else {
+            return []
+        }
+    }
+}
+
+struct BishopRule: PieceRule {
+    var color: PieceColor
+    
+    func movablePositions(current: Position) -> [Position] {
+        let leftTop = leftTopPositions(current: current)
+        let rightTop = rightTopPositions(current: current)
+        let leftBottom = leftBottomPositions(current: current)
+        let rightBottom = rightBottomPositions(current: current)
+        
+        return leftTop + rightTop + leftBottom + rightBottom
+    }
+}
+
+struct LukeRule: PieceRule {
+    var color: PieceColor
+    
+    func movablePositions(current: Position) -> [Position] {
+        let left = leftPositions(current: current)
+        let right = rightPositions(current: current)
+        let top = topPositions(current: current)
+        let bottom = bottomPositions(current: current)
+        
+        return left + right + top + bottom
+    }
+}
+
+struct QueenRule: PieceRule {
+    var color: PieceColor
+    
+    func movablePositions(current: Position) -> [Position] {
+        let leftTop = leftTopPositions(current: current)
+        let rightTop = rightTopPositions(current: current)
+        let leftBottom = leftBottomPositions(current: current)
+        let rightBottom = rightBottomPositions(current: current)
+        
+        let left = leftPositions(current: current)
+        let right = rightPositions(current: current)
+        let top = topPositions(current: current)
+        let bottom = bottomPositions(current: current)
+        
+        return left + right + top + bottom + leftTop + rightTop + leftBottom + rightBottom
+    }
+}

--- a/Chess/Chess/Position.swift
+++ b/Chess/Chess/Position.swift
@@ -8,16 +8,48 @@
 import Foundation
 
 enum BoardRank: Int, CaseIterable {
-    case A, B, C, D, E, F, G, H
-}
-
-enum BoardFile: Int, CaseIterable {
+    static let firstAsciiValue = Character("1").asciiValue!
+    
     case _1, _2, _3, _4, _5, _6, _7, _8
 }
 
+enum BoardFile: Int, CaseIterable {
+    static let firstAsciiValue = Character("A").asciiValue!
+    
+    case A, B, C, D, E, F, G, H
+}
+
 struct Position: Equatable {
-    let rank: BoardRank
-    let file: BoardFile
+    var file: BoardFile
+    var rank: BoardRank
+}
+
+extension BoardRank {
+    static func - (rhs: BoardRank, lhs: Int) -> BoardRank? {
+        guard let nextRank = BoardRank(rawValue: rhs.rawValue - 1) else { return nil }
+        
+        return nextRank
+    }
+    
+    static func + (rhs: BoardRank, lhs: Int) -> BoardRank? {
+        guard let nextRank = BoardRank(rawValue: rhs.rawValue + 1) else { return nil }
+        
+        return nextRank
+    }
+}
+
+extension BoardFile {
+    static func - (rhs: BoardFile, lhs: Int) -> BoardFile? {
+        guard let nextFile = BoardFile(rawValue: rhs.rawValue - 1) else { return nil }
+        
+        return nextFile
+    }
+    
+    static func + (rhs: BoardFile, lhs: Int) -> BoardFile? {
+        guard let nextFile = BoardFile(rawValue: rhs.rawValue + 1) else { return nil }
+        
+        return nextFile
+    }
 }
 
 extension Position {
@@ -27,18 +59,21 @@ extension Position {
     
     init(string: String) throws {
         guard string.count == 2,
-              let rankValue = string.first?.asciiValue,
-              let fileValue = string.last?.asciiValue else {
+              let fileValue = string.first?.asciiValue,
+              let rankValue = string.last?.asciiValue,
+              fileValue >= BoardFile.firstAsciiValue && rankValue >= BoardRank.firstAsciiValue else {
             throw PositionError.invalidString
         }
         
-        let rank = Int(rankValue - Character("A").asciiValue!)
-        let file = Int(fileValue - Character("1").asciiValue!)
+        let rank = Int(rankValue - BoardRank.firstAsciiValue)
+        let file = Int(fileValue - BoardFile.firstAsciiValue)
         
         if let rank = BoardRank(rawValue: rank), let file = BoardFile(rawValue: file) {
-            self.init(rank: rank, file: file)
+            self.init(file: file, rank: rank)
         } else {
             throw PositionError.invalidPosition
         }
     }
 }
+
+extension Position: Hashable {}

--- a/Chess/ChessTests/ChessTests.swift
+++ b/Chess/ChessTests/ChessTests.swift
@@ -30,11 +30,11 @@ class ChessTests: XCTestCase {
         do {
             let positionA1 = try Position(string: "A1")
             
-            XCTAssertTrue(positionA1.rank == .A && positionA1.file == ._1)
+            XCTAssertTrue(positionA1.rank == ._1 && positionA1.file == .A)
             
             let positionC4 = try Position(string: "C4")
             
-            XCTAssertTrue(positionC4.rank == .C && positionC4.file == ._4)
+            XCTAssertTrue(positionC4.rank == ._4 && positionC4.file == .C)
         } catch {
             XCTFail("포지션 텍스트 파싱 실패.")
         }
@@ -44,14 +44,50 @@ class ChessTests: XCTestCase {
         XCTAssertTrue(positionZ1 == nil)
     }
     
+    func testMovablePositions() throws {
+        board.initailizePiece()
+        
+        let predictedLuckPositions = [Position(file: .B, rank: ._1), Position(file: .C, rank: ._1), Position(file: .D, rank: ._1),
+                                      Position(file: .E, rank: ._1), Position(file: .F, rank: ._1), Position(file: .G, rank: ._1),
+                                      Position(file: .H, rank: ._1), Position(file: .A, rank: ._2), Position(file: .A, rank: ._3),
+                                      Position(file: .A, rank: ._4), Position(file: .A, rank: ._5), Position(file: .A, rank: ._6),
+                                      Position(file: .A, rank: ._7), Position(file: .A, rank: ._8)]
+        testPiecePositions(current: Position(file: .A, rank: ._1), predicted: predictedLuckPositions)
+        
+        let predictedPawnPositions = [Position(file: .C, rank: ._3)]
+        testPiecePositions(current: Position(file: .C, rank: ._2), predicted: predictedPawnPositions)
+        
+        let predictedKnightPositions = [Position(file: .A, rank: ._2), Position(file: .C, rank: ._2)]
+        testPiecePositions(current: Position(file: .B, rank: ._1), predicted: predictedKnightPositions)
+        
+        for rank in BoardRank.allCases {
+            for file in BoardFile.allCases {
+                let position = Position(file: file, rank: rank)
+                
+                if let piece = board.piece(position: position) {
+                    let pieceType = "[rank: \(position.rank), file: \(position.file)] \(piece.type)"
+                    print("\(pieceType)\n\(piece.rule.movablePositions(current: position).compactMap({ "rank:\($0.rank) / file:\($0.file)" }).joined(separator: "\n") )")
+                    print("----------------\n")
+                }
+            }
+        }
+    }
+    
+    private func testPiecePositions(current position: Position, predicted positions: [Position]) {
+        let luck = board.piece(position: position)
+        let possiblePositions = luck?.rule.movablePositions(current: position) ?? []
+        
+        XCTAssertTrue(Set(possiblePositions) == Set(positions))
+    }
+    
     func testMovePosition() throws {
         board.initailizePiece()
         board.display()
         
-        let target = Position(rank: .B, file: ._2)
-        let dest = Position(rank: .C, file: ._2)
+        let target = Position(file: .A, rank: ._2)
+        let dest = Position(file: .A, rank: ._3)
         let pawn = board.piece(position: target)
-        let positions = pawn?.movablePositions
+        let positions = pawn?.rule.movablePositions(current: target)
         
         XCTAssertTrue(positions?.first == dest)
         


### PR DESCRIPTION
- PieceRule 및 PieceRule 테스트 케이스 추가하였습니다.
- 이전 코멘트에서 의견주신 "movablePositions 경우는 타입마다 구현 내용이 꽤 달라서 switch-case로 하면 엄청 길어질 수 있지 않을까요?" 이 부분에 대해 고민해보다가 PieceRule 이라는 프로토콜을 만들어서 각 체스말의 이동 규칙을 정의하고 Piece 에 PieceRule 타입의 rule 프로퍼티를 만든 후 각 체스말의 규칙을 정의한 객체(PawnRule, LukeRule 등) 리턴해주도록 설계해보았습니다.
- 또한 보드판의 각 체스말의 예측 경로와 movablePositions 값을 비교하여 테스트 케이스를 추가하였습니다.