### PR TITLE
[Feature-step2] Board 뷰 구성 및 로직 구현 / 테스트 케이스 추가

### DIFF
--- a/Chess/Chess.xcodeproj/project.pbxproj
+++ b/Chess/Chess.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		C2360C792860748B00E117C9 /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360C772860748B00E117C9 /* Piece.swift */; };
 		C2360C7B28615EA300E117C9 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360C7A28615EA300E117C9 /* Position.swift */; };
 		C2360CAD2865A68700E117C9 /* PieceRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360CAC2865A68700E117C9 /* PieceRule.swift */; };
+		C2360CB12869840B00E117C9 /* BoardSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360CB02869840B00E117C9 /* BoardSpace.swift */; };
+		C2360CB32869BB3900E117C9 /* BoardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2360CB22869BB3900E117C9 /* BoardViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +59,8 @@
 		C2360C772860748B00E117C9 /* Piece.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
 		C2360C7A28615EA300E117C9 /* Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
 		C2360CAC2865A68700E117C9 /* PieceRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceRule.swift; sourceTree = "<group>"; };
+		C2360CB02869840B00E117C9 /* BoardSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSpace.swift; sourceTree = "<group>"; };
+		C2360CB22869BB3900E117C9 /* BoardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -110,6 +114,8 @@
 				C2360C752860745100E117C9 /* SupportingFiles */,
 				C2360C492860744500E117C9 /* ViewController.swift */,
 				C2360C762860748B00E117C9 /* Board.swift */,
+				C2360CB02869840B00E117C9 /* BoardSpace.swift */,
+				C2360CB22869BB3900E117C9 /* BoardViewModel.swift */,
 				C2360C772860748B00E117C9 /* Piece.swift */,
 				C2360CAC2865A68700E117C9 /* PieceRule.swift */,
 				C2360C7A28615EA300E117C9 /* Position.swift */,
@@ -280,8 +286,10 @@
 			files = (
 				C2360C4A2860744500E117C9 /* ViewController.swift in Sources */,
 				C2360C462860744500E117C9 /* AppDelegate.swift in Sources */,
+				C2360CB12869840B00E117C9 /* BoardSpace.swift in Sources */,
 				C2360C7B28615EA300E117C9 /* Position.swift in Sources */,
 				C2360C792860748B00E117C9 /* Piece.swift in Sources */,
+				C2360CB32869BB3900E117C9 /* BoardViewModel.swift in Sources */,
 				C2360CAD2865A68700E117C9 /* PieceRule.swift in Sources */,
 				C2360C782860748B00E117C9 /* Board.swift in Sources */,
 				C2360C482860744500E117C9 /* SceneDelegate.swift in Sources */,

--- a/Chess/Chess/Base.lproj/Main.storyboard
+++ b/Chess/Chess/Base.lproj/Main.storyboard
@@ -116,6 +116,7 @@
                     <connections>
                         <outlet property="blackScore" destination="Yce-CI-WKv" id="TSr-pz-6WW"/>
                         <outlet property="board" destination="p83-YX-lbh" id="cyy-A4-Uuv"/>
+                        <outlet property="currentTurnDisplay" destination="2LZ-cO-HDP" id="UJe-VN-JXE"/>
                         <outlet property="whiteScore" destination="fvO-OP-Sl2" id="3xl-MG-pew"/>
                     </connections>
                 </viewController>

--- a/Chess/Chess/Base.lproj/Main.storyboard
+++ b/Chess/Chess/Base.lproj/Main.storyboard
@@ -1,24 +1,132 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Chess" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="era-g6-bCb">
+                                <rect key="frame" x="137.5" y="195" width="139" height="31"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yce-CI-WKv">
+                                        <rect key="frame" x="0.0" y="0.0" width="9.5" height="31"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <segmentedControl opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="2LZ-cO-HDP">
+                                        <rect key="frame" x="19.5" y="0.0" width="100" height="32"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="100" id="6xa-GF-SLz"/>
+                                        </constraints>
+                                        <segments>
+                                            <segment title="흑"/>
+                                            <segment title="백"/>
+                                        </segments>
+                                    </segmentedControl>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fvO-OP-Sl2">
+                                        <rect key="frame" x="129.5" y="0.0" width="9.5" height="31"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="p83-YX-lbh">
+                                <rect key="frame" x="0.0" y="246" width="414" height="414"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="p83-YX-lbh" secondAttribute="height" multiplier="1:1" id="HQd-si-3cE"/>
+                                </constraints>
+                                <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="HID-JV-P9C">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="BoardSpace" id="ijr-Pd-dPu" customClass="BoardSpace" customModule="Chess" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="gAO-cb-o8r">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ggl-Hx-3bY">
+                                                    <rect key="frame" x="64" y="64" width="0.0" height="0.0"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Ggl-Hx-3bY" firstAttribute="centerY" secondItem="gAO-cb-o8r" secondAttribute="centerY" id="V9c-Q8-Q3N"/>
+                                                <constraint firstItem="Ggl-Hx-3bY" firstAttribute="centerX" secondItem="gAO-cb-o8r" secondAttribute="centerX" id="yCt-3e-Iw0"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <connections>
+                                            <outlet property="pieceDisplay" destination="Ggl-Hx-3bY" id="raz-CE-EIS"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                                <connections>
+                                    <outlet property="dataSource" destination="BYZ-38-t0r" id="n7C-i3-o5Z"/>
+                                    <outlet property="delegate" destination="BYZ-38-t0r" id="VaK-xC-yd4"/>
+                                </connections>
+                            </collectionView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OsU-g5-qfF">
+                                <rect key="frame" x="342" y="196.5" width="57" height="28.5"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Reset">
+                                    <fontDescription key="titleFontDescription" type="system" weight="medium" pointSize="12"/>
+                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </buttonConfiguration>
+                                <connections>
+                                    <action selector="resetBoard:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fzk-aQ-hbj"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="p83-YX-lbh" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="50q-nm-80l"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="p83-YX-lbh" secondAttribute="trailing" id="6TH-wT-X41"/>
+                            <constraint firstItem="p83-YX-lbh" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="8Xf-ec-RSX"/>
+                            <constraint firstItem="p83-YX-lbh" firstAttribute="top" secondItem="era-g6-bCb" secondAttribute="bottom" constant="20" id="M9u-D0-tRp"/>
+                            <constraint firstItem="OsU-g5-qfF" firstAttribute="centerY" secondItem="era-g6-bCb" secondAttribute="centerY" id="W1L-Zb-ULS"/>
+                            <constraint firstItem="era-g6-bCb" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="WaG-Bu-otE"/>
+                            <constraint firstItem="p83-YX-lbh" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" id="Yet-1e-Snh"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="OsU-g5-qfF" secondAttribute="trailing" constant="15" id="sCZ-Kz-seO"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="blackScore" destination="Yce-CI-WKv" id="TSr-pz-6WW"/>
+                        <outlet property="board" destination="p83-YX-lbh" id="cyy-A4-Uuv"/>
+                        <outlet property="whiteScore" destination="fvO-OP-Sl2" id="3xl-MG-pew"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="139" y="108"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Chess/Chess/Board.swift
+++ b/Chess/Chess/Board.swift
@@ -6,12 +6,14 @@
 //
 
 import Foundation
+import Combine
 
 final class Board {
     private var pieceSpaces: [Position: Piece] = [:]
     
-    var whiteScore: Int = 0
-    var blackScore: Int = 0
+    var turn: PieceColor = .white
+    var whiteScore = CurrentValueSubject<Int, Never>(0)
+    var blackScore = CurrentValueSubject<Int, Never>(0)
 
     func initailizePiece() {
         pieceSpaces = [:]
@@ -68,11 +70,15 @@ final class Board {
             for position in positionsByDirection {
                 let destPiece = pieceSpaces[position]
                 
-                if targetPiece.color == destPiece?.color {
+                if let destPiece = destPiece {
+                    if targetPiece.color != destPiece.color {
+                        filteredPositions.append(position)
+                    }
+                    
                     break
+                } else {
+                    filteredPositions.append(position)
                 }
-                
-                filteredPositions.append(position)
             }
             
             positions.append(filteredPositions)
@@ -88,10 +94,13 @@ final class Board {
         
         if movablePositions.contains(dest) {
             var targetPiece = targetPiece
+            let destPiece = pieceSpaces[dest]
             
             targetPiece.position = dest
             pieceSpaces.removeValue(forKey: target)
             pieceSpaces[dest] = targetPiece
+            
+            addScore(piece: destPiece)
         }
         
         return movablePositions.contains(dest)
@@ -104,9 +113,9 @@ final class Board {
 
         switch piece.color {
         case .black:
-            whiteScore += piece.score
+            whiteScore.send(whiteScore.value + piece.score)
         case .white:
-            blackScore += piece.score
+            blackScore.send(blackScore.value + piece.score)
         }
     }
 }

--- a/Chess/Chess/BoardSpace.swift
+++ b/Chess/Chess/BoardSpace.swift
@@ -1,0 +1,53 @@
+//
+//  BoardSpace.swift
+//  Chess
+//
+//  Created by kakao on 2022/06/27.
+//
+
+import UIKit
+
+final class BoardSpace: UICollectionViewCell {
+    @IBOutlet weak private var pieceDisplay: UILabel!
+    
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                focusBorder()
+            } else {
+                removeBorder()
+            }
+        }
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        pieceDisplay.text = ""
+        removeBorder()
+    }
+    
+    func setupPiece(_ piece: Piece?) {
+        guard let piece = piece else {
+            return
+        }
+
+        pieceDisplay.text = piece.icon
+    }
+    
+    func configBackgroundColor(in indexPath: IndexPath) {
+        if indexPath.section % 2 == 0 {
+            backgroundColor = indexPath.item % 2 == 0 ? .white : .brown
+        } else {
+            backgroundColor = indexPath.item % 2 == 0 ? .brown : .white
+        }
+    }
+    
+    func focusBorder() {
+        contentView.layer.borderWidth = 2
+        contentView.layer.borderColor = UIColor.blue.cgColor
+    }
+    
+    func removeBorder() {
+        contentView.layer.borderWidth = 0
+    }
+}

--- a/Chess/Chess/BoardViewModel.swift
+++ b/Chess/Chess/BoardViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  BoardViewModel.swift
+//  Chess
+//
+//  Created by kakao on 2022/06/27.
+//
+
+import Foundation
+
+protocol BoardViewModel {
+    var board: Board { get set }
+    var turn: PieceColor { get set }
+    var selectedPosition: Position? { get set }
+    
+    func piece(in position: Position?) -> Piece?
+    func moveBoardSpace(position: Position) throws -> Bool
+}
+
+enum BoardSelectError: Error {
+    case notSelectPiece
+    case equalSelectedPositions
+    case notPossiblePosition
+}
+
+final class BoardViewModelImpl: BoardViewModel {
+    var board: Board = Board()
+    var turn: PieceColor = .white
+    var selectedPosition: Position?
+    
+    func piece(in position: Position?) -> Piece? {
+        guard let position = position else {
+            return nil
+        }
+
+        return board.piece(position: position)
+    }
+    
+    func moveBoardSpace(position: Position) throws -> Bool {
+        if let selectedPosition = selectedPosition {
+            if selectedPosition == position {
+                throw BoardSelectError.equalSelectedPositions
+            } else {
+                if board.movePiece(from: selectedPosition, to: position) {
+                    self.selectedPosition = nil
+                    return true
+                } else {
+                    throw BoardSelectError.notPossiblePosition
+                }
+            }
+        } else {
+            self.selectedPosition = position
+            throw BoardSelectError.notSelectPiece
+        }
+    }
+}

--- a/Chess/Chess/PieceRule.swift
+++ b/Chess/Chess/PieceRule.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol PieceRule {
     var color: PieceColor { get }
     
-    func movablePositions(current: Position) -> [Position]
+    func movablePositions(current: Position) -> [[Position]]
 }
 
 extension PieceRule {
@@ -102,7 +102,7 @@ extension PieceRule {
 struct PawnRule: PieceRule {
     var color: PieceColor
     
-    func movablePositions(current: Position) -> [Position] {
+    func movablePositions(current: Position) -> [[Position]] {
         var newPosition = current
         var nextRank: BoardRank?
         
@@ -115,9 +115,9 @@ struct PawnRule: PieceRule {
         
         if let nextRank = nextRank {
             newPosition.rank = nextRank
-            return [newPosition]
+            return [[newPosition]]
         } else {
-            return []
+            return [[]]
         }
     }
 }
@@ -125,8 +125,7 @@ struct PawnRule: PieceRule {
 struct KnightRule: PieceRule {
     var color: PieceColor
     
-    func movablePositions(current: Position) -> [Position] {
-        var positions: [Position] = []
+    func movablePositions(current: Position) -> [[Position]] {
         var nextRank: BoardRank?
         
         switch color {
@@ -137,17 +136,19 @@ struct KnightRule: PieceRule {
         }
         
         if let nextRank = nextRank {
+            var positions: [[Position]] = []
+            
             if let leftFile = current.file - 1 {
-                positions.append(Position(file: leftFile, rank: nextRank))
+                positions.append([Position(file: leftFile, rank: nextRank)])
             }
             
             if let rightFile = current.file + 1 {
-                positions.append(Position(file: rightFile, rank: nextRank))
+                positions.append([Position(file: rightFile, rank: nextRank)])
             }
             
             return positions
         } else {
-            return []
+            return [[]]
         }
     }
 }
@@ -155,33 +156,33 @@ struct KnightRule: PieceRule {
 struct BishopRule: PieceRule {
     var color: PieceColor
     
-    func movablePositions(current: Position) -> [Position] {
+    func movablePositions(current: Position) -> [[Position]] {
         let leftTop = leftTopPositions(current: current)
         let rightTop = rightTopPositions(current: current)
         let leftBottom = leftBottomPositions(current: current)
         let rightBottom = rightBottomPositions(current: current)
         
-        return leftTop + rightTop + leftBottom + rightBottom
+        return [leftTop] + [rightTop] + [leftBottom] + [rightBottom]
     }
 }
 
 struct LukeRule: PieceRule {
     var color: PieceColor
     
-    func movablePositions(current: Position) -> [Position] {
+    func movablePositions(current: Position) -> [[Position]] {
         let left = leftPositions(current: current)
         let right = rightPositions(current: current)
         let top = topPositions(current: current)
         let bottom = bottomPositions(current: current)
         
-        return left + right + top + bottom
+        return [left] + [right] + [top] + [bottom]
     }
 }
 
 struct QueenRule: PieceRule {
     var color: PieceColor
     
-    func movablePositions(current: Position) -> [Position] {
+    func movablePositions(current: Position) -> [[Position]] {
         let leftTop = leftTopPositions(current: current)
         let rightTop = rightTopPositions(current: current)
         let leftBottom = leftBottomPositions(current: current)
@@ -192,6 +193,6 @@ struct QueenRule: PieceRule {
         let top = topPositions(current: current)
         let bottom = bottomPositions(current: current)
         
-        return left + right + top + bottom + leftTop + rightTop + leftBottom + rightBottom
+        return [left] + [right] + [top] + [bottom] + [leftTop] + [rightTop] + [leftBottom] + [rightBottom]
     }
 }

--- a/Chess/Chess/ViewController.swift
+++ b/Chess/Chess/ViewController.swift
@@ -5,12 +5,16 @@
 //  Created by kakao on 2022/06/20.
 //
 
+import Combine
 import UIKit
 
 class ViewController: UIViewController {
+    private var cancellables = Set<AnyCancellable>()
+    
     @IBOutlet weak var board: UICollectionView!
     @IBOutlet weak var blackScore: UILabel!
     @IBOutlet weak var whiteScore: UILabel!
+    @IBOutlet weak var currentTurnDisplay: UISegmentedControl!
     
     @IBAction func resetBoard(_ sender: UIButton) {
         reset()
@@ -21,19 +25,36 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        viewModel = BoardViewModelImpl()
+        viewModel = BoardViewModel()
         viewModel.board.initailizePiece()
         
         board.allowsMultipleSelection = true
         board.reloadData()
+        
+        initCombine()
+    }
+    
+    private func initCombine() {
+        viewModel.turn.sink(receiveValue: { [weak self] turn in
+            self?.currentTurnDisplay.selectedSegmentIndex = turn == .black ? 0 : 1
+        }).store(in: &cancellables)
+        
+        viewModel.board.whiteScore.sink(receiveValue: { [weak self] whiteScore in
+            self?.whiteScore.text = "\(whiteScore)"
+        }).store(in: &cancellables)
+        
+        viewModel.board.blackScore.sink(receiveValue: { [weak self] blackScore in
+            self?.blackScore.text = "\(blackScore)"
+        }).store(in: &cancellables)
     }
     
     func reset() {
         blackScore.text = "0"
         whiteScore.text = "0"
-        viewModel = BoardViewModelImpl()
+        viewModel = BoardViewModel()
         viewModel.board.initailizePiece()
         board.reloadData()
+        initCombine()
     }
 }
 
@@ -62,19 +83,20 @@ extension ViewController: UICollectionViewDelegate {
         do {
             if try viewModel.moveBoardSpace(position: currentSelectedPosition) {
                 board.reloadData()
+                viewModel.turn.send(viewModel.currentTurn.toggle())
             }
         } catch {
-            switch error {
-            case BoardSelectError.notSelectPiece:
-                viewModel.board.movablePositions(target: currentSelectedPosition).forEach({ position in
-                    let indexPath = IndexPath(item: position.file.rawValue, section: position.rank.rawValue)
-                    let cell = collectionView.cellForItem(at: indexPath) as! BoardSpace
-                    cell.focusBorder()
-                })
-            case BoardSelectError.notPossiblePosition, BoardSelectError.equalSelectedPositions:
-                collectionView.deselectItem(at: indexPath, animated: false)
-            default:
-                break
+            if let selectError = error as? BoardSelectError {
+                switch selectError {
+                case .notSelectPiece:
+                    viewModel.board.movablePositions(target: currentSelectedPosition).forEach({ position in
+                        let indexPath = IndexPath(item: position.file.rawValue, section: position.rank.rawValue)
+                        let cell = collectionView.cellForItem(at: indexPath) as! BoardSpace
+                        cell.focusBorder()
+                    })
+                case .equalSelectedPositions, .notPossiblePosition, .emptyPosition, .notMatchTurn:
+                    collectionView.deselectItem(at: indexPath, animated: false)
+                }
             }
         }
     }

--- a/Chess/Chess/ViewController.swift
+++ b/Chess/Chess/ViewController.swift
@@ -8,12 +8,109 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    @IBOutlet weak var board: UICollectionView!
+    @IBOutlet weak var blackScore: UILabel!
+    @IBOutlet weak var whiteScore: UILabel!
+    
+    @IBAction func resetBoard(_ sender: UIButton) {
+        reset()
+    }
+    
+    private var viewModel: BoardViewModel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+
+        viewModel = BoardViewModelImpl()
+        viewModel.board.initailizePiece()
+        
+        board.allowsMultipleSelection = true
+        board.reloadData()
     }
-
-
+    
+    func reset() {
+        blackScore.text = "0"
+        whiteScore.text = "0"
+        viewModel = BoardViewModelImpl()
+        viewModel.board.initailizePiece()
+        board.reloadData()
+    }
 }
 
+extension ViewController: UICollectionViewDataSource {
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        BoardRank.allCases.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        BoardFile.allCases.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "BoardSpace", for: indexPath) as! BoardSpace
+        let piece = viewModel.piece(in: indexPath.position)
+        cell.setupPiece(piece)
+        cell.configBackgroundColor(in: indexPath)
+        return cell
+    }
+}
+
+extension ViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let currentSelectedPosition = indexPath.position else { return }
+        
+        do {
+            if try viewModel.moveBoardSpace(position: currentSelectedPosition) {
+                board.reloadData()
+            }
+        } catch {
+            switch error {
+            case BoardSelectError.notSelectPiece:
+                viewModel.board.movablePositions(target: currentSelectedPosition).forEach({ position in
+                    let indexPath = IndexPath(item: position.file.rawValue, section: position.rank.rawValue)
+                    let cell = collectionView.cellForItem(at: indexPath) as! BoardSpace
+                    cell.focusBorder()
+                })
+            case BoardSelectError.notPossiblePosition, BoardSelectError.equalSelectedPositions:
+                collectionView.deselectItem(at: indexPath, animated: false)
+            default:
+                break
+            }
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        guard collectionView.indexPathsForSelectedItems?.count == 0 else { return }
+        
+        viewModel.selectedPosition = nil
+        collectionView.indexPathsForSelectedItems?.forEach({ board.deselectItem(at: $0, animated: false) })
+        collectionView.reloadData()
+    }
+}
+
+extension ViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let width = (collectionView.frame.width - 9) / CGFloat(BoardFile.allCases.count)
+        return CGSize(width: width, height: width)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+        UIEdgeInsets(top: 1, left: 1, bottom: 0, right: 1)
+    }
+}
+
+extension IndexPath {
+    var position: Position? {
+        guard let file = BoardFile(rawValue: item), let rank = BoardRank(rawValue: section) else { return nil }
+        
+        return Position(file: file, rank: rank)
+    }
+}

--- a/Chess/ChessTests/ChessTests.swift
+++ b/Chess/ChessTests/ChessTests.swift
@@ -11,14 +11,6 @@ import XCTest
 class ChessTests: XCTestCase {
     private var board = Board()
     
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
     func testInitialize() throws {
         board.initailizePiece()
         board.display()
@@ -47,18 +39,10 @@ class ChessTests: XCTestCase {
     func testMovablePositions() throws {
         board.initailizePiece()
         
-        let predictedLuckPositions = [Position(file: .B, rank: ._1), Position(file: .C, rank: ._1), Position(file: .D, rank: ._1),
-                                      Position(file: .E, rank: ._1), Position(file: .F, rank: ._1), Position(file: .G, rank: ._1),
-                                      Position(file: .H, rank: ._1), Position(file: .A, rank: ._2), Position(file: .A, rank: ._3),
-                                      Position(file: .A, rank: ._4), Position(file: .A, rank: ._5), Position(file: .A, rank: ._6),
-                                      Position(file: .A, rank: ._7), Position(file: .A, rank: ._8)]
-        testPiecePositions(current: Position(file: .A, rank: ._1), predicted: predictedLuckPositions)
-        
         let predictedPawnPositions = [Position(file: .C, rank: ._3)]
         testPiecePositions(current: Position(file: .C, rank: ._2), predicted: predictedPawnPositions)
-        
-        let predictedKnightPositions = [Position(file: .A, rank: ._2), Position(file: .C, rank: ._2)]
-        testPiecePositions(current: Position(file: .B, rank: ._1), predicted: predictedKnightPositions)
+        testPiecePositions(current: Position(file: .B, rank: ._1), predicted: [])
+        testPiecePositions(current: Position(file: .A, rank: ._1), predicted: [])
         
         for rank in BoardRank.allCases {
             for file in BoardFile.allCases {
@@ -66,7 +50,7 @@ class ChessTests: XCTestCase {
                 
                 if let piece = board.piece(position: position) {
                     let pieceType = "[rank: \(position.rank), file: \(position.file)] \(piece.type)"
-                    print("\(pieceType)\n\(piece.rule.movablePositions(current: position).compactMap({ "rank:\($0.rank) / file:\($0.file)" }).joined(separator: "\n") )")
+                    print("\(pieceType)\n\(board.movablePositions(target: position).compactMap({ "rank:\($0.rank) / file:\($0.file)" }).joined(separator: "\n") )")
                     print("----------------\n")
                 }
             }
@@ -74,8 +58,7 @@ class ChessTests: XCTestCase {
     }
     
     private func testPiecePositions(current position: Position, predicted positions: [Position]) {
-        let luck = board.piece(position: position)
-        let possiblePositions = luck?.rule.movablePositions(current: position) ?? []
+        let possiblePositions = board.movablePositions(target: position)
         
         XCTAssertTrue(Set(possiblePositions) == Set(positions))
     }
@@ -86,10 +69,9 @@ class ChessTests: XCTestCase {
         
         let target = Position(file: .A, rank: ._2)
         let dest = Position(file: .A, rank: ._3)
-        let pawn = board.piece(position: target)
-        let positions = pawn?.rule.movablePositions(current: target)
+        let positions = board.movablePositions(target: target)
         
-        XCTAssertTrue(positions?.first == dest)
+        XCTAssertTrue(positions.first == dest)
         
         let isMovePiece = board.movePiece(from: target, to: dest)
         
@@ -97,5 +79,19 @@ class ChessTests: XCTestCase {
         
         board.display()
         print("white : \(board.whiteScore)\nblack : \(board.blackScore)")
+    }
+    
+    func testScore() throws {
+        let pawn = ChessPiece(color: .black, type: .pawn, position: Position(file: .A, rank: ._2))
+        
+        board.addScore(piece: pawn)
+        
+        XCTAssertTrue(board.whiteScore == pawn.score)
+        
+        let knight = ChessPiece(color: .black, type: .knight, position: Position(file: .B, rank: ._1))
+        
+        board.addScore(piece: knight)
+        
+        XCTAssertTrue(board.whiteScore == (pawn.score + knight.score))
     }
 }


### PR DESCRIPTION
- 체스판 뷰 구성은 CollectionView 로 구성하고 ViewController 에 Datasource와 Delegate를 적용했습니다.
- 뷰를 구성할 때 로직을 분리하고 테스트에 용이하도록 BoardViewModel을 만들었습니다.
- Board 에 스코어 추가가 정상적을 되는지 테스트 케이스를 추가했습니다.
- Board 에서 체스판을 2차원 배열로 관리하던 부분을 Dictionary 타입으로 변환했습니다.
- PieceRule(체스말의 이동가능한 모든 경로) - Board(보드위 체스말 위치에 따른 이동가능한 경로 필터링) - BoardViewModel(특수 혹은 예외를 필터링) 순으로 체스말의 이동가능한 경로를 가져오도록 로직을 분리하고 관리하도록 적용했습니다. 