### PR TITLE
Feature step2.1

### DIFF
--- a/swift-chessgame/swift-chessgame.xcodeproj/project.pbxproj
+++ b/swift-chessgame/swift-chessgame.xcodeproj/project.pbxproj
@@ -24,6 +24,10 @@
 		67B2387028606E2C008D7936 /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2386F28606E2C008D7936 /* Piece.swift */; };
 		67B2387228606E5F008D7936 /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2387128606E5F008D7936 /* Pawn.swift */; };
 		67B238822860B74F008D7936 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B238812860B74F008D7936 /* Coordinate.swift */; };
+		67EF444F2869810B002E441D /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EF444E2869810B002E441D /* BoardView.swift */; };
+		67EF4454286982B2002E441D /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 67EF4453286982B2002E441D /* SnapKit */; };
+		67EF44642869864B002E441D /* PieceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EF44632869864B002E441D /* PieceView.swift */; };
+		67EF446628698C97002E441D /* IndexPathExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67EF446528698C97002E441D /* IndexPathExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +69,9 @@
 		67B2386F28606E2C008D7936 /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
 		67B2387128606E5F008D7936 /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
 		67B238812860B74F008D7936 /* Coordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinate.swift; sourceTree = "<group>"; };
+		67EF444E2869810B002E441D /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
+		67EF44632869864B002E441D /* PieceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceView.swift; sourceTree = "<group>"; };
+		67EF446528698C97002E441D /* IndexPathExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexPathExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,6 +79,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				67EF4454286982B2002E441D /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -118,7 +126,8 @@
 				67B2383128605551008D7936 /* AppDelegate.swift */,
 				67B2383328605551008D7936 /* SceneDelegate.swift */,
 				67B2383528605551008D7936 /* ViewController.swift */,
-				67B23861286055DB008D7936 /* Board.swift */,
+				67EF445028698110002E441D /* View */,
+				67EF445128698120002E441D /* Board */,
 				67B238802860B747008D7936 /* Common */,
 				67B2386728606D98008D7936 /* Piece */,
 				67B2383728605551008D7936 /* Main.storyboard */,
@@ -163,8 +172,34 @@
 			isa = PBXGroup;
 			children = (
 				67B238812860B74F008D7936 /* Coordinate.swift */,
+				67EF446528698C97002E441D /* IndexPathExtensions.swift */,
 			);
 			path = Common;
+			sourceTree = "<group>";
+		};
+		67EF445028698110002E441D /* View */ = {
+			isa = PBXGroup;
+			children = (
+				67EF444E2869810B002E441D /* BoardView.swift */,
+				67EF446228698640002E441D /* ReusableView */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		67EF445128698120002E441D /* Board */ = {
+			isa = PBXGroup;
+			children = (
+				67B23861286055DB008D7936 /* Board.swift */,
+			);
+			path = Board;
+			sourceTree = "<group>";
+		};
+		67EF446228698640002E441D /* ReusableView */ = {
+			isa = PBXGroup;
+			children = (
+				67EF44632869864B002E441D /* PieceView.swift */,
+			);
+			path = ReusableView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -183,6 +218,9 @@
 			dependencies = (
 			);
 			name = "swift-chessgame";
+			packageProductDependencies = (
+				67EF4453286982B2002E441D /* SnapKit */,
+			);
 			productName = "swift-chessgame";
 			productReference = 67B2382E28605551008D7936 /* swift-chessgame.app */;
 			productType = "com.apple.product-type.application";
@@ -255,6 +293,9 @@
 				Base,
 			);
 			mainGroup = 67B2382528605551008D7936;
+			packageReferences = (
+				67EF4452286982B2002E441D /* XCRemoteSwiftPackageReference "SnapKit" */,
+			);
 			productRefGroup = 67B2382F28605551008D7936 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -303,11 +344,14 @@
 				67B2383228605551008D7936 /* AppDelegate.swift in Sources */,
 				674864D728636DDA0027E13F /* Queen.swift in Sources */,
 				674864D328636AB40027E13F /* Rook.swift in Sources */,
+				67EF446628698C97002E441D /* IndexPathExtensions.swift in Sources */,
 				674864D528636DD50027E13F /* Knight.swift in Sources */,
 				67B2387228606E5F008D7936 /* Pawn.swift in Sources */,
 				674864D128636AA90027E13F /* Bishop.swift in Sources */,
 				67B2387028606E2C008D7936 /* Piece.swift in Sources */,
+				67EF444F2869810B002E441D /* BoardView.swift in Sources */,
 				67B23862286055DB008D7936 /* Board.swift in Sources */,
+				67EF44642869864B002E441D /* PieceView.swift in Sources */,
 				67B2383428605551008D7936 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -650,6 +694,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		67EF4452286982B2002E441D /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit";
+			requirement = {
+				branch = develop;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		67EF4453286982B2002E441D /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 67EF4452286982B2002E441D /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 67B2382628605551008D7936 /* Project object */;
 }

--- a/swift-chessgame/swift-chessgame.xcodeproj/project.pbxproj
+++ b/swift-chessgame/swift-chessgame.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		674864D128636AA90027E13F /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674864D028636AA90027E13F /* Bishop.swift */; };
+		674864D328636AB40027E13F /* Rook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674864D228636AB40027E13F /* Rook.swift */; };
+		674864D528636DD50027E13F /* Knight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674864D428636DD50027E13F /* Knight.swift */; };
+		674864D728636DDA0027E13F /* Queen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674864D628636DDA0027E13F /* Queen.swift */; };
 		67B2383228605551008D7936 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2383128605551008D7936 /* AppDelegate.swift */; };
 		67B2383428605551008D7936 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2383328605551008D7936 /* SceneDelegate.swift */; };
 		67B2383628605551008D7936 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B2383528605551008D7936 /* ViewController.swift */; };
@@ -40,6 +44,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		674864D028636AA90027E13F /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
+		674864D228636AB40027E13F /* Rook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rook.swift; sourceTree = "<group>"; };
+		674864D428636DD50027E13F /* Knight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Knight.swift; sourceTree = "<group>"; };
+		674864D628636DDA0027E13F /* Queen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queen.swift; sourceTree = "<group>"; };
 		67B2382E28605551008D7936 /* swift-chessgame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "swift-chessgame.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		67B2383128605551008D7936 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		67B2383328605551008D7936 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -143,6 +151,10 @@
 			children = (
 				67B2386F28606E2C008D7936 /* Piece.swift */,
 				67B2387128606E5F008D7936 /* Pawn.swift */,
+				674864D028636AA90027E13F /* Bishop.swift */,
+				674864D228636AB40027E13F /* Rook.swift */,
+				674864D428636DD50027E13F /* Knight.swift */,
+				674864D628636DDA0027E13F /* Queen.swift */,
 			);
 			path = Piece;
 			sourceTree = "<group>";
@@ -289,7 +301,11 @@
 				67B238822860B74F008D7936 /* Coordinate.swift in Sources */,
 				67B2383628605551008D7936 /* ViewController.swift in Sources */,
 				67B2383228605551008D7936 /* AppDelegate.swift in Sources */,
+				674864D728636DDA0027E13F /* Queen.swift in Sources */,
+				674864D328636AB40027E13F /* Rook.swift in Sources */,
+				674864D528636DD50027E13F /* Knight.swift in Sources */,
 				67B2387228606E5F008D7936 /* Pawn.swift in Sources */,
+				674864D128636AA90027E13F /* Bishop.swift in Sources */,
 				67B2387028606E2C008D7936 /* Piece.swift in Sources */,
 				67B23862286055DB008D7936 /* Board.swift in Sources */,
 				67B2383428605551008D7936 /* SceneDelegate.swift in Sources */,

--- a/swift-chessgame/swift-chessgame/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/swift-chessgame/swift-chessgame/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -72,6 +72,11 @@
     },
     {
       "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
       "scale" : "2x",
       "size" : "76x76"
     },

--- a/swift-chessgame/swift-chessgame/Base.lproj/Main.storyboard
+++ b/swift-chessgame/swift-chessgame/Base.lproj/Main.storyboard
@@ -1,24 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="swift_chessgame" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="139" y="129"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/swift-chessgame/swift-chessgame/Board.swift
+++ b/swift-chessgame/swift-chessgame/Board.swift
@@ -38,6 +38,24 @@ final class Board: BoardProtocol {
             let position = Coordinate(rank: .seven, file: file)
             self.create(Pawn(color: .white), at: position)
         }
+        
+        self.create(Bishop(color: .black), at: Coordinate(rank: .one, file: .C))
+        self.create(Bishop(color: .black), at: Coordinate(rank: .one, file: .F))
+        self.create(Bishop(color: .white), at: Coordinate(rank: .eight, file: .C))
+        self.create(Bishop(color: .white), at: Coordinate(rank: .eight, file: .F))
+        
+        self.create(Rook(color: .black), at: Coordinate(rank: .one, file: .A))
+        self.create(Rook(color: .black), at: Coordinate(rank: .one, file: .H))
+        self.create(Rook(color: .white), at: Coordinate(rank: .eight, file: .A))
+        self.create(Rook(color: .white), at: Coordinate(rank: .eight, file: .H))
+        
+        self.create(Knight(color: .black), at: Coordinate(rank: .one, file: .B))
+        self.create(Knight(color: .black), at: Coordinate(rank: .one, file: .G))
+        self.create(Knight(color: .white), at: Coordinate(rank: .eight, file: .B))
+        self.create(Knight(color: .white), at: Coordinate(rank: .eight, file: .G))
+        
+        self.create(Queen(color: .black), at: Coordinate(rank: .one, file: .E))
+        self.create(Queen(color: .white), at: Coordinate(rank: .eight, file: .E))
     }
     
     // MARK: - Requirement1 print current score
@@ -89,8 +107,22 @@ final class Board: BoardProtocol {
             return false
         }
         
-        let candidates = fromPiece.candidates(from: fromPosition)
-        if candidates.isEmpty || !candidates.contains(toPosition) {
+        let vaildCandidate = fromPiece
+            .candidates(from: fromPosition)
+            .first(where: { [weak self] candidate in
+                guard let self = self else { return false }
+                if candidate.destination == toPosition {
+                    if let transit = candidate.transit {
+                        return self.boardInfo[transit] == nil
+                    } else {
+                        return true
+                    }
+                } else {
+                    return false
+                }
+            })
+        
+        if vaildCandidate == nil {
             return false
         }
     

--- a/swift-chessgame/swift-chessgame/Common/Coordinate.swift
+++ b/swift-chessgame/swift-chessgame/Common/Coordinate.swift
@@ -36,6 +36,9 @@ struct Coordinate: Hashable {
     static let ranks: [Rank] = Rank.allCases
     static let files: [File] = File.allCases
     
+    static var maxColumn: Int { File.H.rawValue }
+    static var maxRow: Int { Rank.eight.rawValue }
+    
     let rank: Rank
     let file: File
     
@@ -71,11 +74,11 @@ struct Coordinate: Hashable {
 
 struct Candidate {
     let destination: Coordinate
-    let transit: Coordinate?
+    let transits: [Coordinate]?
 }
 
 extension Candidate {
     init(destination: Coordinate) {
-        self.init(destination: destination, transit: nil)
+        self.init(destination: destination, transits: nil)
     }
 }

--- a/swift-chessgame/swift-chessgame/Common/Coordinate.swift
+++ b/swift-chessgame/swift-chessgame/Common/Coordinate.swift
@@ -7,18 +7,27 @@
 
 import Foundation
 
+struct Unit {
+    let rank: Int
+    let file: Int
+    
+    static func +(lhs: Unit, rhs: Unit) -> Unit {
+        Unit(rank: lhs.rank + rhs.rank, file: lhs.file + rhs.file)
+    }
+}
+
 enum Direction {
     case up
     case down
     case left
     case right
     
-    var unit: (rank: Int, file: Int) {
+    var unit: Unit {
         switch self {
-        case .up:    return (-1, 0)
-        case .down:  return (1, 0)
-        case .left:  return (0, -1)
-        case .right: return (0, 1)
+        case .up:    return Unit(rank: -1, file: 0)
+        case .down:  return Unit(rank: 1, file: 0)
+        case .left:  return Unit(rank: 0, file: -1)
+        case .right: return Unit(rank: 0, file: 1)
         }
     }
 }
@@ -49,5 +58,24 @@ struct Coordinate: Hashable {
             return nil
         }
         return Coordinate(rank: newRank, file: newFile)
+    }
+    
+    func move(count: Int, unit: Unit) -> Coordinate? {
+        guard let newRank = Rank(rawValue: self.rank.rawValue + unit.rank * count),
+              let newFile = File(rawValue: self.file.rawValue + unit.file * count) else {
+            return nil
+        }
+        return Coordinate(rank: newRank, file: newFile)
+    }
+}
+
+struct Candidate {
+    let destination: Coordinate
+    let transit: Coordinate?
+}
+
+extension Candidate {
+    init(destination: Coordinate) {
+        self.init(destination: destination, transit: nil)
     }
 }

--- a/swift-chessgame/swift-chessgame/Common/IndexPathExtensions.swift
+++ b/swift-chessgame/swift-chessgame/Common/IndexPathExtensions.swift
@@ -1,0 +1,35 @@
+//
+//  IndexPathExtensions.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/27.
+//
+
+import Foundation
+
+extension IndexPath {
+    var rank: Coordinate.Rank? {
+        Coordinate.Rank(rawValue: self.item / Coordinate.maxRow + 1)
+    }
+    
+    var file: Coordinate.File? {
+        Coordinate.File(rawValue: self.item % Coordinate.maxColumn + 1)
+    }
+    
+    var position: Coordinate? {
+        guard let rank = rank,
+              let file = file else {
+            return nil
+        }
+        return Coordinate(rank: rank, file: file)
+    }
+}
+
+extension Coordinate {
+    var indexPath: IndexPath {
+        return IndexPath(
+            item: (self.rank.rawValue - 1) * Coordinate.maxRow + self.file.rawValue - 1,
+            section: 0
+        )
+    }
+}

--- a/swift-chessgame/swift-chessgame/Piece/Bishop.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Bishop.swift
@@ -1,0 +1,35 @@
+//
+//  Bishop.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/23.
+//
+
+import Foundation
+
+struct Bishop: Piece {
+    let color: PieceColor
+    let kind: PieceKind = .bishop
+    
+    func candidates(from position: Coordinate) -> [Candidate] {
+        var candidates: [Candidate] = []
+        let units: [Unit] = [
+            Direction.up.unit + Direction.left.unit,
+            Direction.up.unit + Direction.right.unit,
+            Direction.down.unit + Direction.left.unit,
+            Direction.down.unit + Direction.right.unit
+        ]
+        
+        units.forEach { unit in
+            for count in 1... {
+                if let finalPosition = position.move(count: count, unit: unit) {
+                    candidates.append(Candidate(destination: finalPosition))
+                } else {
+                    break
+                }
+            }
+        }
+        
+        return candidates
+    }
+}

--- a/swift-chessgame/swift-chessgame/Piece/Bishop.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Bishop.swift
@@ -21,9 +21,11 @@ struct Bishop: Piece {
         ]
         
         units.forEach { unit in
+            var transit: [Coordinate] = []
             for count in 1... {
                 if let finalPosition = position.move(count: count, unit: unit) {
-                    candidates.append(Candidate(destination: finalPosition))
+                    candidates.append(Candidate(destination: finalPosition, transits: transit))
+                    transit.append(finalPosition)
                 } else {
                     break
                 }

--- a/swift-chessgame/swift-chessgame/Piece/Knight.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Knight.swift
@@ -1,0 +1,31 @@
+//
+//  Knight.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/23.
+//
+
+import Foundation
+
+struct Knight: Piece {
+    let color: PieceColor
+    let kind: PieceKind = .knight
+    
+    func candidates(from position: Coordinate) -> [Candidate] {
+        var candidates: [Candidate] = []
+        let units: [(first: Unit, second: Unit)] = [
+            (Direction.up.unit, Direction.left.unit),
+            (Direction.up.unit, Direction.right.unit),
+            (Direction.down.unit, Direction.left.unit),
+            (Direction.down.unit, Direction.right.unit)
+        ]
+        
+        units.forEach { unit in
+            if let firstPosition = position.move(count: 1, unit: unit.first),
+               let finalPosition = firstPosition.move(count: 1, unit: unit.second) {
+                candidates.append(Candidate(destination: finalPosition, transit: firstPosition))
+            }
+        }
+        return candidates
+    }
+}

--- a/swift-chessgame/swift-chessgame/Piece/Knight.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Knight.swift
@@ -14,16 +14,20 @@ struct Knight: Piece {
     func candidates(from position: Coordinate) -> [Candidate] {
         var candidates: [Candidate] = []
         let units: [(first: Unit, second: Unit)] = [
-            (Direction.up.unit, Direction.left.unit),
-            (Direction.up.unit, Direction.right.unit),
-            (Direction.down.unit, Direction.left.unit),
-            (Direction.down.unit, Direction.right.unit)
+            (Direction.up.unit, Direction.left.unit + Direction.up.unit),
+            (Direction.up.unit, Direction.right.unit + Direction.up.unit),
+            (Direction.down.unit, Direction.left.unit + Direction.down.unit),
+            (Direction.down.unit, Direction.right.unit + Direction.down.unit),
+            (Direction.left.unit, Direction.left.unit + Direction.up.unit),
+            (Direction.left.unit, Direction.left.unit + Direction.down.unit),
+            (Direction.right.unit, Direction.right.unit + Direction.up.unit),
+            (Direction.right.unit, Direction.right.unit + Direction.down.unit),
         ]
         
         units.forEach { unit in
             if let firstPosition = position.move(count: 1, unit: unit.first),
                let finalPosition = firstPosition.move(count: 1, unit: unit.second) {
-                candidates.append(Candidate(destination: finalPosition, transit: firstPosition))
+                candidates.append(Candidate(destination: finalPosition, transits: [firstPosition]))
             }
         }
         return candidates

--- a/swift-chessgame/swift-chessgame/Piece/Pawn.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Pawn.swift
@@ -11,11 +11,13 @@ struct Pawn: Piece {
     let color: PieceColor
     let kind: PieceKind = .pawn
     
-    func candidates(from position: Coordinate) -> [Coordinate] {
-        var candidates: [Coordinate] = []
-        if let candidate = position.move(count: 1, direction: self.direction) {
-            candidates.append(candidate)
+    func candidates(from position: Coordinate) -> [Candidate] {
+        var candidates: [Candidate] = []
+        let direction: Direction = color == .black ? .down : .up
+        if let finalPosition = position.move(count: 1, direction: direction) {
+            candidates.append(Candidate(destination: finalPosition))
         }
+        
         return candidates
     }
 }

--- a/swift-chessgame/swift-chessgame/Piece/Piece.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Piece.swift
@@ -9,25 +9,29 @@ import Foundation
 
 enum PieceKind {
     case pawn
+    case bishop
+    case rook
+    case knight
+    case queen
     
     var score: Int {
         switch self {
         case .pawn: return 1
+        case .bishop, .knight: return 3
+        case .rook: return 5
+        case .queen: return 9
         }
     }
     
     var descriptions: (black: String, white: String) {
         switch self {
         case .pawn: return ("♟", "♙")
+        case .bishop: return ("♝", "♗")
+        case .rook: return ("♜", "♖")
+        case .knight: return ("♞", "♘")
+        case .queen: return ("♛", "♕")
         }
     }
-    
-    var directions: (black: Direction, white: Direction) {
-        switch self {
-        case .pawn: return (.down, .up)
-        }
-    }
-
 }
 
 enum PieceColor {
@@ -39,7 +43,7 @@ protocol Piece {
     var kind: PieceKind { get }
     
     // Requirement7 piece provide movable position based on current position
-    func candidates(from position: Coordinate) -> [Coordinate]
+    func candidates(from position: Coordinate) -> [Candidate]
 }
 
 extension Piece {
@@ -47,13 +51,6 @@ extension Piece {
         switch self.color {
         case .black: return self.kind.descriptions.black
         case .white: return self.kind.descriptions.white
-        }
-    }
-    
-    var direction: Direction {
-        switch self.color {
-        case .black: return self.kind.directions.black
-        case .white: return self.kind.directions.white
         }
     }
 }

--- a/swift-chessgame/swift-chessgame/Piece/Piece.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Piece.swift
@@ -36,6 +36,13 @@ enum PieceKind {
 
 enum PieceColor {
     case black, white
+    
+    mutating func turnEnd(){
+        switch self {
+        case .white: self = .black
+        case .black: self = .white
+        }
+    }
 }
 
 protocol Piece {

--- a/swift-chessgame/swift-chessgame/Piece/Queen.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Queen.swift
@@ -25,9 +25,11 @@ struct Queen: Piece {
         ]
         
         units.forEach { unit in
+            var transits: [Coordinate] = []
             for count in 1... {
                 if let finalPosition = position.move(count: count, unit: unit) {
-                    candidates.append(Candidate(destination: finalPosition))
+                    candidates.append(Candidate(destination: finalPosition, transits: transits))
+                    transits.append(finalPosition)
                 } else {
                     break
                 }

--- a/swift-chessgame/swift-chessgame/Piece/Queen.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Queen.swift
@@ -1,0 +1,39 @@
+//
+//  Queen.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/23.
+//
+
+import Foundation
+
+struct Queen: Piece {
+    let color: PieceColor
+    let kind: PieceKind = .queen
+    
+    func candidates(from position: Coordinate) -> [Candidate] {
+        var candidates: [Candidate] = []
+        let units: [Unit] = [
+            Direction.up.unit + Direction.left.unit,
+            Direction.up.unit + Direction.right.unit,
+            Direction.down.unit + Direction.left.unit,
+            Direction.down.unit + Direction.right.unit,
+            Direction.up.unit,
+            Direction.down.unit,
+            Direction.left.unit,
+            Direction.right.unit
+        ]
+        
+        units.forEach { unit in
+            for count in 1... {
+                if let finalPosition = position.move(count: count, unit: unit) {
+                    candidates.append(Candidate(destination: finalPosition))
+                } else {
+                    break
+                }
+            }
+        }
+
+        return candidates
+    }
+}

--- a/swift-chessgame/swift-chessgame/Piece/Rook.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Rook.swift
@@ -21,9 +21,11 @@ struct Rook: Piece {
         ]
         
         directions.forEach { direction in
+            var transit: [Coordinate] = []
             for count in 1... {
                 if let finalPosition = position.move(count: count, direction: direction) {
-                    candidates.append(Candidate(destination: finalPosition))
+                    candidates.append(Candidate(destination: finalPosition, transits: transit))
+                    transit.append(finalPosition)
                 } else {
                     break
                 }

--- a/swift-chessgame/swift-chessgame/Piece/Rook.swift
+++ b/swift-chessgame/swift-chessgame/Piece/Rook.swift
@@ -1,0 +1,35 @@
+//
+//  Rook.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/23.
+//
+
+import Foundation
+
+struct Rook: Piece {
+    let color: PieceColor
+    let kind: PieceKind = .rook
+    
+    func candidates(from position: Coordinate) -> [Candidate] {
+        var candidates: [Candidate] = []
+        let directions: [Direction] = [
+            .up,
+            .down,
+            .left,
+            .right
+        ]
+        
+        directions.forEach { direction in
+            for count in 1... {
+                if let finalPosition = position.move(count: count, direction: direction) {
+                    candidates.append(Candidate(destination: finalPosition))
+                } else {
+                    break
+                }
+            }
+        }
+
+        return candidates
+    }
+}

--- a/swift-chessgame/swift-chessgame/View/BoardView.swift
+++ b/swift-chessgame/swift-chessgame/View/BoardView.swift
@@ -1,0 +1,160 @@
+//
+//  BoardView.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/27.
+//
+
+import UIKit
+import SnapKit
+import Foundation
+
+protocol BoardControllable {
+    var board: BoardProtocol { get }
+    
+    func select(position: Coordinate, in cell: PieceCell)
+    func deselect()
+    func move(fromPosition: Coordinate, toPosition: Coordinate)
+    func endTurn()
+}
+
+class BoardView: UIView, BoardControllable, UICollectionViewDataSource, UICollectionViewDelegate {
+    private var maxColumn: Int { Coordinate.maxColumn }
+    private var maxRow: Int { Coordinate.maxRow }
+    
+    // MARK: - UI
+    lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+        collectionView.register(PieceCell.self, forCellWithReuseIdentifier: PieceCell.reuseIdentifier)
+        collectionView.collectionViewLayout = self.layout
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        return collectionView
+    }()
+    
+    // MARK: - Properties
+    let board: BoardProtocol
+    var selectedPosition: Coordinate?
+    var side: PieceColor = .white
+    
+    var feedbackGenerator: UIFeedbackGenerator?
+    
+    // MARK: - Initializing
+    init(board: BoardProtocol) {
+        self.board = board
+        self.board.initialize()
+        super.init(frame: .zero)
+        self.setupViews()
+        self.feedbackGenerator = UIFeedbackGenerator()
+        self.feedbackGenerator?.prepare()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    private func setupViews() {
+        self.addSubview(self.collectionView)
+        self.collectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        self.collectionView.backgroundColor = .black.withAlphaComponent(0.1)
+    }
+    
+    // MARK: - Layout
+    var layout: UICollectionViewCompositionalLayout {
+        UICollectionViewCompositionalLayout { section, _ in
+            let item = NSCollectionLayoutItem(
+                layoutSize: .init(
+                    widthDimension: .fractionalWidth(1/8),
+                    heightDimension: .estimated(PieceCell.height)
+                )
+            )
+            let group = NSCollectionLayoutGroup.horizontal(
+                layoutSize: .init(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .absolute(PieceCell.height)
+                ),
+                subitem: item,
+                count: 8
+            )
+            group.interItemSpacing = .fixed(5)
+            
+            let section = NSCollectionLayoutSection(group: group)
+            section.interGroupSpacing = 5
+            return section
+        }
+    }
+    
+    // MARK: - Board Controll
+    func select(position: Coordinate, in cell: PieceCell) {
+        guard let piece = self.board.piece(at: position),
+              piece.color == side else { return }
+    
+        cell.pieceSelected = true
+        self.board
+            .movablePositions(of: piece, from: position)
+            .map { position in position.indexPath }
+            .compactMap { [weak self] indexPath in
+                self?.collectionView.cellForItem(at: indexPath) as? PieceCell
+            }
+            .forEach { pieceCell in
+                pieceCell.borderActivated = true
+            }
+        self.selectedPosition = position
+    }
+    
+    func deselect() {
+        self.selectedPosition = nil
+        self.collectionView.reloadData()
+    }
+    
+    func move(fromPosition: Coordinate, toPosition: Coordinate) {
+        self.board.move(fromPosition: fromPosition, toPosition: toPosition)
+        self.collectionView.reloadData()
+        self.endTurn()
+    }
+    
+    func endTurn() {
+        self.selectedPosition = nil
+        self.side.turnEnd()
+    }
+    
+    // MARK: - CollectionViewDelegate
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? PieceCell,
+              let position = indexPath.position else { return }
+
+        if let selectedPosition = self.selectedPosition {
+            if selectedPosition == position {
+                self.deselect()
+            } else if cell.borderActivated {
+                self.move(fromPosition: selectedPosition, toPosition: position)
+            }
+        } else {
+            self.select(position: position, in: cell)
+        }
+    }
+    
+    
+    // MARK: - CollectionViewDataSource
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.maxRow * self.maxColumn
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PieceCell.reuseIdentifier, for: indexPath) as? PieceCell else {
+            return UICollectionViewCell()
+        }
+    
+        if let position = indexPath.position,
+           let piece = self.board.piece(at: position)
+        {
+            cell.peice = piece
+        }
+        cell.borderActivated = false
+        cell.pieceSelected = false
+        return cell
+    }
+}

--- a/swift-chessgame/swift-chessgame/View/ReusableView/PieceView.swift
+++ b/swift-chessgame/swift-chessgame/View/ReusableView/PieceView.swift
@@ -1,0 +1,73 @@
+//
+//  PieceView.swift
+//  swift-chessgame
+//
+//  Created by 이상윤 on 2022/06/27.
+//
+
+import Foundation
+import UIKit
+import SnapKit
+
+class PieceCell: UICollectionViewCell {
+    static var height: CGFloat { 45 }
+    static var reuseIdentifier: String { "PieceCell" }
+    
+    // MARK: - UI
+    let pieceLabel: UILabel = {
+        let pieceLabel = UILabel()
+        pieceLabel.font = .systemFont(ofSize: 30, weight: .bold)
+        pieceLabel.textColor = .black
+        return pieceLabel
+    }()
+    
+    
+    // MARK: - Properties
+    var peice: Piece? {
+        didSet {
+            guard let peice = self.peice else { return }
+            self.pieceLabel.text = peice.description
+        }
+    }
+    
+    var borderActivated: Bool = false {
+        didSet {
+            self.layer.borderWidth = self.borderActivated ? 1 : 0
+        }
+    }
+    
+    var pieceSelected: Bool = false {
+        didSet {
+            self.layer.borderWidth = self.pieceSelected ? 2 : 0
+        }
+    }
+    
+    
+    // MARK: - Initializing
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupViews()
+        self.applyStyle()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func prepareForReuse() {
+        self.pieceLabel.text = ""
+        self.borderActivated = false
+    }
+    
+    private func setupViews() {
+        self.contentView.addSubview(self.pieceLabel)
+        self.pieceLabel.snp.makeConstraints {
+            $0.centerX.centerY.equalToSuperview()
+        }
+    }
+    
+    private func applyStyle() {
+        self.backgroundColor = .white
+        self.layer.borderColor = UIColor.black.cgColor
+    }
+}

--- a/swift-chessgame/swift-chessgame/ViewController.swift
+++ b/swift-chessgame/swift-chessgame/ViewController.swift
@@ -6,14 +6,22 @@
 //
 
 import UIKit
+import SnapKit
 
 class ViewController: UIViewController {
 
+    let boardView: UIView = BoardView(board: Board())
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        self.setupViews()
     }
-
-
+    
+    private func setupViews() {
+        self.view.addSubview(self.boardView)
+        self.boardView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
 }
 


### PR DESCRIPTION
> Bishop, Kinght, Queen, Rook 에대한 설계사항은 지난주 그룹레포트에 적어두었습니다
https://docs.google.com/document/d/1_gZyQn-SG1TXTr165L9UzI0tsebkvEsyfb3LLdxg8GQ/edit#
diago.y: 
Pawn외에 여러말들이 추가되면서 PawnKind enum에 있던 Direction정보를 현재말에서 갈수 있는 위치를 반환하는 Piece의 candidates 메서드로 옮겼습니다. 
대각선과 같은 여러 움직임을 표현하기 위해 기존 위,아래,왼쪽, 오른쪽의 Direction보다 작은 단위의 Unit 구초체를 선언하고 Direction을 조합해서 움직임을 나타낼수 있게 했습니다. 
Knight의 경우 전진시 구조물이 있으면 움직일수 없기에 단순 갈수있는 위치가 아닌 이전 위치 정보가 필요해 Candidate라는 목적지 정보외에도 경유지 위치 정보를 기록할수 있는 구조체를 추가했습니다.

아래부터는 이번주 설계사항입니다

# BoardView와 PieceCell
보드와 피스를 보여줄뷰를 구성했습니다. 
컬렉션뷰를 이용해 각 Piece는 셀로 구성되었습니다.

# 갈수있는 위치를 보여주기
이번주 구현사항에 말을 선택시 말이 갈수 있는 경로의 뷰에 테두리를 추가하는 명세가 있었습니다.
또한 앞에 다른말이 가로막고 있을경우 말이 진행할수 없다는 조건이 있어 해당조건이 반영되지않은 기존 구현을 수정할필요가 있었습니다
기존 나이트에서 전진한 자리에 말이 있는지 없는지 체크하는데 쓰이던 Candidate 구조체의 transit 프로퍼티를 transits 컬렉션으로 변경하여 피스를 제외한 모든 말들에 똑같이 transits를 설정하도록 변경했습니다. board에서 해당 transits 정보를 이용해 다른말이 가로막고 있을경우 움직일수 없다 판단을 할수있도록 했습니다.

# Turn 개념의 추가
turn의 개념이 추가되면서 PieceColor를 보드뷰에서 가지고 있게 되었습니다. 턴이 끝나면 해당 색을 반대색으로 바꾸며 이프로퍼티는 다른 로직을 진행하는데 참고합니다.

# 아쉬운점
1. **뷰로직과 데이터로직의 혼재.** 현재 뷰에 관련된 로직과 데이터에 관련된 로직이 보드뷰에 혼재되어있어 가독성이 떨어지며 유연하다고 느껴지지 않는것 같습니다. 
* 보드뷰: 턴을 나타내는 프로퍼티도 보드뷰가 들고 있는데 이또한 보드로 옮기고 보드뷰는 오롯이 보드를 뷰로 표현하고 액션에대한 인풋을 받는 용도로 사용되는게 나을것 같습니다. 보드뷰의 비지니스 로직을 보드로 모두 옮기는게 좋을것 같습니다.
* 피스셀: 체스판에서 말이 선택되었을때 갈수있는 위치의 경우 테두리를 그리는 로직이 있는데, 이를 처리하기위해서 PieceCell과 Piece 객체 사이 PieceViewModel을 두어 Piece객체외에 보더가 그려져있는지를 나타내는 프로퍼티를 가지는 뷰모델을 별도로 두어야할지 고민입니다. 현재는 해당 프로퍼티를 PieceCell에 두고있는데 이렇게 처리하니 보드뷰에서 데이터로직을 수행할때 데이터가 아닌 뷰를 참고해서 로직을 진행하는 경우가있어 뷰를 나타내기위한 별도 데이터모델을 두어야하는지 궁금합니다. 아니면 Piece객체가 보더가 그려져있는지를 나타내는 프로퍼티를 가지는것은 이상해 보이는데 어떤방식이 좋을까요

4. **테스트 코드의 부재.** 테스트 코드가 거의작성되지 못하다보니 코드를 변경할때마다 직접 프로그램을 실행해서 검증하는 방법을 많이 사용했습니다. 시간이 없어 테스트 코드를 많이 작성하지 못했는데 테스트코드 작성이필수적인것으로 보입니다.

5. **검증의 중복** 말이 선택되었을때 갈수 있는 경로를 나타내기 위해 Piece 객체의 candidates 메서드 들에 대해 Board의 canMove 메서드를 사용하여 실제로 말이 이동할수 있는( 테두리를 그려야하는 ) 위치를 선정합니다. 그런데 선택된 말이 이동할수 있는 위치로 이동할때 보드의 move함수를 이용해 이동하는데 이 move함수안에 다시 canMove함수가 들어있어 검증이 두번 일어나게 됩니다. Board에서 단순히 이동만 할수 있는 함수를 별도로 열어주면 검증은 두번일어나지 않을것으로 보이는데 검증이 없이 이동할수 있는 함수를 보드뷰에 열어줘도 될지 고민이 됩니다.

