### PR TITLE
[Step2]

### DIFF
--- a/ChessGame/ChessGame.xcodeproj/project.pbxproj
+++ b/ChessGame/ChessGame.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		C2057FF428608988009F992E /* PieceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2057FEB286088F6009F992E /* PieceType.swift */; };
 		C24D52942861A0B800E4730D /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E228182861587F00BF657F /* Pawn.swift */; };
 		C24D52962861A65200E4730D /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24D52952861A65200E4730D /* Bishop.swift */; };
+		C2538D342869923000779A0D /* StackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2538D332869923000779A0D /* StackView.swift */; };
+		C2538D362869935300779A0D /* PositionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2538D352869935300779A0D /* PositionButton.swift */; };
+		C2C184EB28698A6200FFB52B /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24D52952861A65200E4730D /* Bishop.swift */; };
 		C2CDFAB32860876E003F79DB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CDFAB22860876E003F79DB /* AppDelegate.swift */; };
 		C2CDFAB52860876E003F79DB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CDFAB42860876E003F79DB /* SceneDelegate.swift */; };
 		C2CDFAB72860876E003F79DB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2CDFAB62860876E003F79DB /* ViewController.swift */; };
@@ -60,6 +63,8 @@
 		C2057FEB286088F6009F992E /* PieceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceType.swift; sourceTree = "<group>"; };
 		C2057FED28608918009F992E /* Movable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movable.swift; sourceTree = "<group>"; };
 		C24D52952861A65200E4730D /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
+		C2538D332869923000779A0D /* StackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackView.swift; sourceTree = "<group>"; };
+		C2538D352869935300779A0D /* PositionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionButton.swift; sourceTree = "<group>"; };
 		C2CDFAAF2860876E003F79DB /* ChessGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C2CDFAB22860876E003F79DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C2CDFAB42860876E003F79DB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -123,6 +128,15 @@
 			path = Protocols;
 			sourceTree = "<group>";
 		};
+		C2538D322869922200779A0D /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				C2538D332869923000779A0D /* StackView.swift */,
+				C2538D352869935300779A0D /* PositionButton.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		C2CDFAA62860876E003F79DB = {
 			isa = PBXGroup;
 			children = (
@@ -146,6 +160,7 @@
 		C2CDFAB12860876E003F79DB /* ChessGame */ = {
 			isa = PBXGroup;
 			children = (
+				C2538D322869922200779A0D /* Views */,
 				C2E2281E28615AEC00BF657F /* Extensions */,
 				C2E2281A28615A7B00BF657F /* Utilitys */,
 				C2057FE928608896009F992E /* Protocols */,
@@ -335,7 +350,9 @@
 			files = (
 				C2E228192861587F00BF657F /* Pawn.swift in Sources */,
 				C2CDFAB72860876E003F79DB /* ViewController.swift in Sources */,
+				C2538D342869923000779A0D /* StackView.swift in Sources */,
 				C2CDFAB32860876E003F79DB /* AppDelegate.swift in Sources */,
+				C2538D362869935300779A0D /* PositionButton.swift in Sources */,
 				C2057FE728608890009F992E /* Board.swift in Sources */,
 				C2CDFAB52860876E003F79DB /* SceneDelegate.swift in Sources */,
 				C2057FEC286088F6009F992E /* PieceType.swift in Sources */,
@@ -358,6 +375,7 @@
 				C2057FF428608988009F992E /* PieceType.swift in Sources */,
 				C2057FF02860897F009F992E /* Board.swift in Sources */,
 				C24D52942861A0B800E4730D /* Pawn.swift in Sources */,
+				C2C184EB28698A6200FFB52B /* Bishop.swift in Sources */,
 				C2057FF128608982009F992E /* Player.swift in Sources */,
 				C2057FEF28608966009F992E /* Match.swift in Sources */,
 				C2E2282428615D6300BF657F /* StringConverter.swift in Sources */,
@@ -535,6 +553,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -563,6 +582,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ChessGame/ChessGame/Models/Board.swift
+++ b/ChessGame/ChessGame/Models/Board.swift
@@ -8,20 +8,27 @@
 import Foundation
 
 class Board {
-    var pieces: [PieceType] = []
+    var pieces: [Position: PieceType] = [:]
     
     func reset() {
         initializePieces()
     }
     
     private func initializePieces() {
-        pieces.removeAll(keepingCapacity: true)
+        pieces.removeAll()
         for color in PieceColor.colors {
             for stringPosition in Pawn.StartPosition[color.rawValue] {
                 guard let position = StringConverter.convertToPosition(stringPosition) else {
                     return
                 }
-                pieces.append(Pawn(position: position, color: color))
+                pieces[position] = Pawn(position: position, color: color)
+            }
+            
+            for stringPosition in Bishop.StartablePosition[color.rawValue] {
+                guard let position = StringConverter.convertToPosition(stringPosition) else {
+                    return
+                }
+                pieces[position] = Bishop(position: position, color: color)
             }
         }
     }

--- a/ChessGame/ChessGame/Models/Match.swift
+++ b/ChessGame/ChessGame/Models/Match.swift
@@ -20,7 +20,7 @@ class Match {
             var rowString = ""
             for rank in Position.Ranks {
                 if let position = Position(rank: rank, file: file) {
-                    if let piece = board.pieces.first(where: { $0.position == position }) {
+                    if let piece = board.pieces[position] {
                         rowString.append(piece.pieceString)
                     } else {
                         rowString.append(".")

--- a/ChessGame/ChessGame/Models/Pieces/Bishop.swift
+++ b/ChessGame/ChessGame/Models/Pieces/Bishop.swift
@@ -24,7 +24,7 @@ final class Bishop: PieceType {
         }
     }
     
-    var movablePosition: [Position] {
+    var movablePositions: [Position] {
         let positions: [Position] = []
         
         return positions
@@ -41,7 +41,7 @@ final class Bishop: PieceType {
     }
     
     func canMove(to position: Position) -> Bool {
-        if movablePosition.contains(where: { $0 == position }) {
+        if movablePositions.contains(where: { $0 == position }) {
             return true
         }
         return false

--- a/ChessGame/ChessGame/Models/Pieces/Bishop.swift
+++ b/ChessGame/ChessGame/Models/Pieces/Bishop.swift
@@ -8,12 +8,7 @@
 import Foundation
 
 final class Bishop: PieceType {
-    enum PositionSide: Int {
-        case left = 0
-        case right = 1
-    }
     static let StartablePosition: [[String]] = [["C8", "F8"], ["C1", "F1"]]
-    var positionSide: PositionSide = .left
     var position: Position
     var color: PieceColor
     var pieceString: String {
@@ -33,11 +28,6 @@ final class Bishop: PieceType {
     init(position: Position, color: PieceColor) {
         self.position = position
         self.color = color
-    }
-    
-    convenience init(position: Position, color: PieceColor, positionSide: PositionSide) {
-        self.init(position: position, color: color)
-        self.positionSide = positionSide
     }
     
     func canMove(to position: Position) -> Bool {

--- a/ChessGame/ChessGame/Models/Pieces/Pawn.swift
+++ b/ChessGame/ChessGame/Models/Pieces/Pawn.swift
@@ -15,14 +15,16 @@ final class Pawn: PieceType {
         if color == .black {
             return "♟"
         } else {
-            return  "♙"
+            return "♙"
         }
     }
     
-    var movablePosition: [Position] {
+    var movablePositions: [Position] {
         var positions: [Position] = []
         
         if color == .black, let movablePosition = Position(rank: Character(UnicodeScalar(position.getRankNum() + 1)!), file: position.file) {
+            positions.append(movablePosition)
+        } else if color == .white, let movablePosition = Position(rank: Character(UnicodeScalar(position.getRankNum() - 1)!), file: position.file) {
             positions.append(movablePosition)
         }
         
@@ -35,14 +37,13 @@ final class Pawn: PieceType {
     }
     
     func canMove(to position: Position) -> Bool {
-        if movablePosition.contains(where: { $0 == position }) {
+        if movablePositions.contains(where: { $0 == position }) {
             return true
         }
         return false
     }
     
     func move(to position: Position) {
-        
     }
 }
 

--- a/ChessGame/ChessGame/Models/Position.swift
+++ b/ChessGame/ChessGame/Models/Position.swift
@@ -7,11 +7,15 @@
 
 import Foundation
 
-class Position: Equatable {
+class Position: Hashable {
     static let Ranks: [Character] = ["A", "B", "C", "D", "E", "F", "G", "H"]
     static let Files: [Character] = ["1", "2", "3", "4", "5", "6", "7", "8"]
     var rank: Character
     var file: Character
+    
+    var toString: String {
+        "\(self.rank)\(self.file)"
+    }
     
     init?(rank: Character, file: Character) {
         if Self.Ranks.contains(rank), Self.Files.contains(file) {
@@ -29,25 +33,26 @@ class Position: Equatable {
         
         return false
     }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(rank)
+        hasher.combine(file)
+    }
 }
 
 // MARK: Convert Position
 extension Position {
     func getRankNum() -> Int {
-        let byte = rank.asciiValue
-        var value: Int = 0
-        value = value << 8
-        value = value | Int(byte!)
+        let rankAscValue = rank.asciiValue!
+        let num = Int(rankAscValue - ("A" as Character).asciiValue!)
         
-        return value
+        return num
     }
     
     func getFileNum() -> Int {
-        let byte = file.asciiValue
-        var value: Int = 0
-        value = value << 8
-        value = value | Int(byte!)
+        let fileAscValue = file.asciiValue!
+        let num = Int(fileAscValue - ("1" as Character).asciiValue!)
         
-        return value
+        return num
     }
 }

--- a/ChessGame/ChessGame/Protocols/Movable.swift
+++ b/ChessGame/ChessGame/Protocols/Movable.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol Movable {
-    var movablePosition: [Position] { get }
+    var movablePositions: [Position] { get }
     func canMove(to position: Position) -> Bool
     func move(to position: Position)
 }

--- a/ChessGame/ChessGame/ViewController.swift
+++ b/ChessGame/ChessGame/ViewController.swift
@@ -10,12 +10,86 @@ import UIKit
 class ViewController: UIViewController {
 
     let match = Match()
+    lazy var rankStackView = RankStackView()
+    var touchButtonPositions: [Position?] = Array(repeating: nil, count: 2)
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        view.backgroundColor = .cyan
+        touchButtonPositions.removeAll()
+        setupView()
+        initButtons()
+        initPieces()
+    }
+    
+    private func setupView() {
+        view.addSubview(rankStackView)
+        NSLayoutConstraint.activate([
+            rankStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            rankStackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            rankStackView.heightAnchor.constraint(equalToConstant: UIScreen.main.bounds.width),
+            rankStackView.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width)
+        ])
+    }
+    
+    private func initButtons() {
+        for rank in Position.Ranks {
+            for file in Position.Files {
+                let positionString = "\(rank)\(file)"
+                guard let position = StringConverter.convertToPosition(positionString) else {
+                    return
+                }
+                
+                // 현재 View 계층 구조가 RankStackView(BoardView 역할) > FileStackView > PositionButton 으로 이루어져있는데
+                // 버튼에 액션을 부여하기 위해서 BoardView를 통해 해당 Position의 버튼을 가져와 액션을 주입합니다.
+                // 동작에 대한 코드는 VC에 있는 것이 맞다고 생각하였지만
+                // 이렇게 상위 뷰에서 하위 뷰의 컴포넌트를 가져와도 되는건지 궁금합니다.
+                rankStackView.getButtonAt(position).touchUpAction = { [weak self] position, piece in
+                    guard let self = self else {
+                        return
+                    }
+                    
+                    switch self.touchButtonPositions.count {
+                    case 0:
+                        guard let piece = piece else {
+                            print("해당 공간에 기물이 없습니다.")
+                            return
+                        }
+                        print("\(position.toString) 위치의 \(piece.pieceString) 를 선택하였습니다.")
+                        self.touchButtonPositions.append(position)
+                    case 1:
+                        guard let piecePosition = self.touchButtonPositions[0],
+                              let piece = self.match.board.pieces[piecePosition],
+                              piece.movablePositions.contains(position) else {
+                            print("기물이 이동할 수 없는 위치\(position.toString)입니다.")
+                            self.touchButtonPositions.removeAll()
+                            return
+                        }
+                        
+                        if let targetPiece = self.match.board.pieces[position] {
+                            print("\(position.toString) 위치로 이동하여 \(targetPiece.pieceString)를 잡습니다.")
+                        } else {
+                            print("\(position.toString) 위치로 이동합니다.")
+                        }
+                        self.touchButtonPositions.removeAll()
+                        
+                    case 2:
+                        break
+                    default:
+                        break
+                    }
+                }
+            }
+        }
+    }
+    
+    private func initPieces() {
         match.reset()
-        match.printBoard()
+        for (position, piece) in match.board.pieces {
+            let positionButton = rankStackView.getButtonAt(position)
+            positionButton.piece = piece
+            positionButton.setTitle(piece.pieceString, for: .normal)
+        }
     }
 
 }

--- a/ChessGame/ChessGame/Views/PositionButton.swift
+++ b/ChessGame/ChessGame/Views/PositionButton.swift
@@ -1,0 +1,32 @@
+//
+//  PositionButton.swift
+//  ChessGame
+//
+//  Created by 지현우 on 2022/06/27.
+//
+
+import UIKit
+
+class PositionButton: UIButton {
+    var position: Position
+    var piece: PieceType?
+    var touchUpAction: ((Position, PieceType?) -> ())?
+    
+    init(position: Position, piece: PieceType? = nil) {
+        self.position = position
+        self.piece = piece
+        super.init(frame: .zero)
+        backgroundColor = .lightGray
+        addTarget(nil, action: #selector(didTapButton), for: .touchUpInside)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc
+    private func didTapButton() {
+        touchUpAction?(position, piece)
+    }
+    
+}

--- a/ChessGame/ChessGame/Views/StackView.swift
+++ b/ChessGame/ChessGame/Views/StackView.swift
@@ -1,0 +1,72 @@
+//
+//  BoardView.swift
+//  ChessGame
+//
+//  Created by 지현우 on 2022/06/27.
+//
+
+import UIKit
+
+class RankStackView: UIStackView {
+    private var fileStackViews: [FileStackView] = []
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+        backgroundColor = .black
+        axis = .vertical
+        translatesAutoresizingMaskIntoConstraints = false
+        distribution = .fillEqually
+        spacing = 2
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        for index in 0...7 {
+            let fileStackView = FileStackView(rank: Position.Ranks[index])
+            self.fileStackViews.append(fileStackView)
+            self.addArrangedSubview(fileStackView)
+        }
+    }
+    
+    func getButtonAt(_ position: Position) -> PositionButton {
+        let rank = position.getRankNum()
+        let file = position.getFileNum()
+        return fileStackViews[file].positionButtons[rank]
+    }
+}
+
+class FileStackView: UIStackView {
+    var rank: Character
+    fileprivate var positionButtons: [PositionButton] = []
+    
+    init(rank: Character) {
+        self.rank = rank
+        super.init(frame: .zero)
+        backgroundColor = .black
+        axis = .horizontal
+        translatesAutoresizingMaskIntoConstraints = false
+        distribution = .fillEqually
+        spacing = 2
+        setupView()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        for index in 0...7 {
+            guard let position = Position(rank: self.rank, file: Position.Files[index]) else {
+                return
+            }
+            let button = PositionButton(position: position)
+            self.positionButtons.append(button)
+            self.addArrangedSubview(button)
+        }
+    }
+    
+}

--- a/ChessGame/ChessGameTests/ChessGameTests.swift
+++ b/ChessGame/ChessGameTests/ChessGameTests.swift
@@ -30,19 +30,43 @@ class ChessTests: XCTestCase {
         XCTAssertNil(position)
     }
     
-    func testResetPieces_OnlyPawn_success() {
+    func testResetPieces_Pawn_success() {
         match.reset()
-        let pieces = match.board.pieces
+        let pawns = match.board.pieces
+            .compactMap({ key, value in
+                value
+            })
+            .filter({ $0 is Pawn })
+            .sorted {
+                $0.position.rank < $1.position.rank
+            }
         
-        let whitePawnPositions = pieces.filter({ $0.color == .white }).map({ $0.position })
-        let blackPawnPositions = pieces.filter({ $0.color == .black }).map({ $0.position })
+        let whitePawnPositions = pawns.filter({ $0.color == .white }).map({ $0.position })
+        let blackPawnPositions = pawns.filter({ $0.color == .black }).map({ $0.position })
         
-        XCTAssertEqual(pieces.count, 16)
+        XCTAssertEqual(pawns.count, 16)
         XCTAssertEqual(whitePawnPositions.count, 8)
         XCTAssertEqual(blackPawnPositions.count, 8)
         
-        XCTAssertEqual(whitePawnPositions.map({ "\($0.rank)\($0.file)" }), Pawn.StartPosition[0])
-        XCTAssertEqual(blackPawnPositions.map({ "\($0.rank)\($0.file)" }), Pawn.StartPosition[1])
+        XCTAssertEqual(whitePawnPositions.map({ "\($0.rank)\($0.file)" }), Pawn.StartPosition[PieceColor.white.rawValue])
+        XCTAssertEqual(blackPawnPositions.map({ "\($0.rank)\($0.file)" }), Pawn.StartPosition[PieceColor.black.rawValue])
+    }
+    
+    func testResetPieces_Bishop_success() {
+        match.reset()
+        let bishops = match.board.pieces.compactMap({ key, value in
+            value
+        }).filter({ $0 is Bishop })
+        
+        let whiteBishopPosition = bishops.filter({ $0.color == .white }).map({ $0.position }).first
+        let blackBishopPosition = bishops.filter({ $0.color == .black }).map({ $0.position }).first
+        
+        XCTAssertEqual(bishops.count, 4)
+        XCTAssertNotNil(whiteBishopPosition)
+        XCTAssertNotNil(blackBishopPosition)
+        
+        XCTAssertTrue(Bishop.StartablePosition[PieceColor.white.rawValue].contains(whiteBishopPosition.map({ "\($0.rank)\($0.file)" })!))
+        XCTAssertTrue(Bishop.StartablePosition[PieceColor.black.rawValue].contains(blackBishopPosition.map({ "\($0.rank)\($0.file)" })!))
     }
 
 }

--- a/ChessGame/ChessGameUITests/ChessGameUITests.swift
+++ b/ChessGame/ChessGameUITests/ChessGameUITests.swift
@@ -29,13 +29,4 @@ class ChessGameUITests: XCTestCase {
 
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
-
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
-    }
 }


### PR DESCRIPTION
# 작업 및 수정 사항
비숍 생성, 비숍 생성 테스트 작성
보드 내 Pieces 관리 배열 > 딕셔너리
RankStackView, FileStackView, PositionButton 정의 및 생성
Rank, File Ascii를 이용해 Int로 변경하던 로직 수정
수정 여파로 movablePositions 동작 x -> 테스트코드 생성 필요
touchButtonPositions Property 이용해 선택한 2개의 Position 관리
각 버튼들에 TouchAction 주입

### 비숍 생성
비숍은 위치가 고정되어 있어 static Property로 PositionString을 받아 해당 위치에 생성합니다.

### View 구조
8x8로 크기가 정해져있고 VC에 Delegate/DataSource 코드를 구현하는 CollectionView보다는 StackView로 간단하게 구현하는 게 낫다고 생각하여 StackView로 View 계층 구조를 구현하였습니다.

BoardView의 역할을 하는 RankStackView > FileStackView > PositionButton 으로 이루어져있고
혹여나 다른 View들에도 액션이 필요하다면 VC에서 관리/주입 하는 것이 깔끔하다고 생각하여 각 버튼들의 touchAction을 VC에서 주입하였습니다.

### Step1의 로직에서 변경
기존에 Position Class 내에 getRank/FileNum() 메소드를 통해 Character -> Int 로 전환해주고 있었는데
내부 로직을 변경하였고 내부 로직이 변경되면서 해당 메소드를 사용하는 모든 부분들에서의 수정이 필요했으며
기존 Step1 때에 해당 메소드에 대한 테스트코드가 존재하지 않아 정상동작을 하고 있다고 생각하여서
현재 해당 메소드를 사용하고 있는 부분들에서 정상동작을 하고 있지 않습니다.
-> 이런 경험을 통해 조금이나마 초반에 테스트코드를 작성할 때, 당연히 동작할 것이라는 코드들도 이후의 수정 가능성을 고려해 테스트를 작성해야한다는 것을 깨달았습니다.
-> 질문? 테스트 코드는 많을수록 좋다고 어디선가 들은 것 같은데 비즈니스 로직을 수행하는 함수 이외 각 객체의 생성/객체 내 메소드 / 계산 Property 들도 테스트 코드를 짜두는 것이 과연 좋은지 궁금합니다.

### 살아있는 Pieces 관리
기존에 [PieceType] 배열로 관리하고 있던 것을 [Position: PieceType] 딕셔너리로 수정하였습니다.
제 프로젝트 구조에서는 Board를 나타내는 2차원 배열을 갖고 있지 않기에 각 Piece들이 이동하고 이동가능한 위치를 판단하기 위해서는  살아있는 Piece들의 위치와 가고자하는 위치를 비교해야합니다. 
이때 O(n) 의 시간복잡도가 계산되는데, 이를 딕셔너리로 바꿔 복잡도를 줄였습니다.


