### PR TITLE
[체스게임] [Step2] 체스 말 선택 및 후보 보여주는 동작 구현

### DIFF
--- a/Chess/Chess.xcodeproj/project.pbxproj
+++ b/Chess/Chess.xcodeproj/project.pbxproj
@@ -1,0 +1,603 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D2BD8D3928604D3600A486A4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D3828604D3600A486A4 /* AppDelegate.swift */; };
+		D2BD8D3B28604D3600A486A4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D3A28604D3600A486A4 /* SceneDelegate.swift */; };
+		D2BD8D3D28604D3600A486A4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D3C28604D3600A486A4 /* ViewController.swift */; };
+		D2BD8D4028604D3600A486A4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2BD8D3E28604D3600A486A4 /* Main.storyboard */; };
+		D2BD8D4228604D3700A486A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D2BD8D4128604D3700A486A4 /* Assets.xcassets */; };
+		D2BD8D4528604D3700A486A4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2BD8D4328604D3700A486A4 /* LaunchScreen.storyboard */; };
+		D2BD8D5028604D3700A486A4 /* ChessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D4F28604D3700A486A4 /* ChessTests.swift */; };
+		D2BD8D5A28604D3700A486A4 /* ChessUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D5928604D3700A486A4 /* ChessUITests.swift */; };
+		D2BD8D5C28604D3700A486A4 /* ChessUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D5B28604D3700A486A4 /* ChessUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D2BD8D4C28604D3700A486A4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D2BD8D2D28604D3600A486A4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D2BD8D3428604D3600A486A4;
+			remoteInfo = Chess;
+		};
+		D2BD8D5628604D3700A486A4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D2BD8D2D28604D3600A486A4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D2BD8D3428604D3600A486A4;
+			remoteInfo = Chess;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		D2BD8D3528604D3600A486A4 /* Chess.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Chess.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2BD8D3828604D3600A486A4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D2BD8D3A28604D3600A486A4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		D2BD8D3C28604D3600A486A4 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		D2BD8D3F28604D3600A486A4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		D2BD8D4128604D3700A486A4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D2BD8D4428604D3700A486A4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D2BD8D4628604D3700A486A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D2BD8D4B28604D3700A486A4 /* ChessTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2BD8D4F28604D3700A486A4 /* ChessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessTests.swift; sourceTree = "<group>"; };
+		D2BD8D5528604D3700A486A4 /* ChessUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2BD8D5928604D3700A486A4 /* ChessUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessUITests.swift; sourceTree = "<group>"; };
+		D2BD8D5B28604D3700A486A4 /* ChessUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D2BD8D3228604D3600A486A4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2BD8D4828604D3700A486A4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2BD8D5228604D3700A486A4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D2BD8D2C28604D3600A486A4 = {
+			isa = PBXGroup;
+			children = (
+				D2BD8D3728604D3600A486A4 /* Chess */,
+				D2BD8D4E28604D3700A486A4 /* ChessTests */,
+				D2BD8D5828604D3700A486A4 /* ChessUITests */,
+				D2BD8D3628604D3600A486A4 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D2BD8D3628604D3600A486A4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D2BD8D3528604D3600A486A4 /* Chess.app */,
+				D2BD8D4B28604D3700A486A4 /* ChessTests.xctest */,
+				D2BD8D5528604D3700A486A4 /* ChessUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D2BD8D3728604D3600A486A4 /* Chess */ = {
+			isa = PBXGroup;
+			children = (
+				D2BD8D3828604D3600A486A4 /* AppDelegate.swift */,
+				D2BD8D3A28604D3600A486A4 /* SceneDelegate.swift */,
+				D2BD8D3C28604D3600A486A4 /* ViewController.swift */,
+				D2BD8D3E28604D3600A486A4 /* Main.storyboard */,
+				D2BD8D4128604D3700A486A4 /* Assets.xcassets */,
+				D2BD8D4328604D3700A486A4 /* LaunchScreen.storyboard */,
+				D2BD8D4628604D3700A486A4 /* Info.plist */,
+			);
+			path = Chess;
+			sourceTree = "<group>";
+		};
+		D2BD8D4E28604D3700A486A4 /* ChessTests */ = {
+			isa = PBXGroup;
+			children = (
+				D2BD8D4F28604D3700A486A4 /* ChessTests.swift */,
+			);
+			path = ChessTests;
+			sourceTree = "<group>";
+		};
+		D2BD8D5828604D3700A486A4 /* ChessUITests */ = {
+			isa = PBXGroup;
+			children = (
+				D2BD8D5928604D3700A486A4 /* ChessUITests.swift */,
+				D2BD8D5B28604D3700A486A4 /* ChessUITestsLaunchTests.swift */,
+			);
+			path = ChessUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D2BD8D3428604D3600A486A4 /* Chess */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D2BD8D5F28604D3700A486A4 /* Build configuration list for PBXNativeTarget "Chess" */;
+			buildPhases = (
+				D2BD8D3128604D3600A486A4 /* Sources */,
+				D2BD8D3228604D3600A486A4 /* Frameworks */,
+				D2BD8D3328604D3600A486A4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Chess;
+			productName = Chess;
+			productReference = D2BD8D3528604D3600A486A4 /* Chess.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D2BD8D4A28604D3700A486A4 /* ChessTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D2BD8D6228604D3700A486A4 /* Build configuration list for PBXNativeTarget "ChessTests" */;
+			buildPhases = (
+				D2BD8D4728604D3700A486A4 /* Sources */,
+				D2BD8D4828604D3700A486A4 /* Frameworks */,
+				D2BD8D4928604D3700A486A4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D2BD8D4D28604D3700A486A4 /* PBXTargetDependency */,
+			);
+			name = ChessTests;
+			productName = ChessTests;
+			productReference = D2BD8D4B28604D3700A486A4 /* ChessTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D2BD8D5428604D3700A486A4 /* ChessUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D2BD8D6528604D3700A486A4 /* Build configuration list for PBXNativeTarget "ChessUITests" */;
+			buildPhases = (
+				D2BD8D5128604D3700A486A4 /* Sources */,
+				D2BD8D5228604D3700A486A4 /* Frameworks */,
+				D2BD8D5328604D3700A486A4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D2BD8D5728604D3700A486A4 /* PBXTargetDependency */,
+			);
+			name = ChessUITests;
+			productName = ChessUITests;
+			productReference = D2BD8D5528604D3700A486A4 /* ChessUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D2BD8D2D28604D3600A486A4 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					D2BD8D3428604D3600A486A4 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					D2BD8D4A28604D3700A486A4 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = D2BD8D3428604D3600A486A4;
+					};
+					D2BD8D5428604D3700A486A4 = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = D2BD8D3428604D3600A486A4;
+					};
+				};
+			};
+			buildConfigurationList = D2BD8D3028604D3600A486A4 /* Build configuration list for PBXProject "Chess" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D2BD8D2C28604D3600A486A4;
+			productRefGroup = D2BD8D3628604D3600A486A4 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D2BD8D3428604D3600A486A4 /* Chess */,
+				D2BD8D4A28604D3700A486A4 /* ChessTests */,
+				D2BD8D5428604D3700A486A4 /* ChessUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D2BD8D3328604D3600A486A4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2BD8D4528604D3700A486A4 /* LaunchScreen.storyboard in Resources */,
+				D2BD8D4228604D3700A486A4 /* Assets.xcassets in Resources */,
+				D2BD8D4028604D3600A486A4 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2BD8D4928604D3700A486A4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2BD8D5328604D3700A486A4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D2BD8D3128604D3600A486A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2BD8D3D28604D3600A486A4 /* ViewController.swift in Sources */,
+				D2BD8D3928604D3600A486A4 /* AppDelegate.swift in Sources */,
+				D2BD8D3B28604D3600A486A4 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2BD8D4728604D3700A486A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2BD8D5028604D3700A486A4 /* ChessTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D2BD8D5128604D3700A486A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D2BD8D5A28604D3700A486A4 /* ChessUITests.swift in Sources */,
+				D2BD8D5C28604D3700A486A4 /* ChessUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D2BD8D4D28604D3700A486A4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D2BD8D3428604D3600A486A4 /* Chess */;
+			targetProxy = D2BD8D4C28604D3700A486A4 /* PBXContainerItemProxy */;
+		};
+		D2BD8D5728604D3700A486A4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D2BD8D3428604D3600A486A4 /* Chess */;
+			targetProxy = D2BD8D5628604D3700A486A4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		D2BD8D3E28604D3600A486A4 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D2BD8D3F28604D3600A486A4 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		D2BD8D4328604D3700A486A4 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D2BD8D4428604D3700A486A4 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		D2BD8D5D28604D3700A486A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		D2BD8D5E28604D3700A486A4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D2BD8D6028604D3700A486A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Chess/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hailey.Chess;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D2BD8D6128604D3700A486A4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Chess/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hailey.Chess;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D2BD8D6328604D3700A486A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hailey.ChessTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Chess.app/Chess";
+			};
+			name = Debug;
+		};
+		D2BD8D6428604D3700A486A4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hailey.ChessTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Chess.app/Chess";
+			};
+			name = Release;
+		};
+		D2BD8D6628604D3700A486A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hailey.ChessUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Chess;
+			};
+			name = Debug;
+		};
+		D2BD8D6728604D3700A486A4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hailey.ChessUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Chess;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D2BD8D3028604D3600A486A4 /* Build configuration list for PBXProject "Chess" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D2BD8D5D28604D3700A486A4 /* Debug */,
+				D2BD8D5E28604D3700A486A4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D2BD8D5F28604D3700A486A4 /* Build configuration list for PBXNativeTarget "Chess" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D2BD8D6028604D3700A486A4 /* Debug */,
+				D2BD8D6128604D3700A486A4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D2BD8D6228604D3700A486A4 /* Build configuration list for PBXNativeTarget "ChessTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D2BD8D6328604D3700A486A4 /* Debug */,
+				D2BD8D6428604D3700A486A4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D2BD8D6528604D3700A486A4 /* Build configuration list for PBXNativeTarget "ChessUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D2BD8D6628604D3700A486A4 /* Debug */,
+				D2BD8D6728604D3700A486A4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D2BD8D2D28604D3600A486A4 /* Project object */;
+}

--- a/Chess/Chess.xcodeproj/project.pbxproj
+++ b/Chess/Chess.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		D2BD8D5028604D3700A486A4 /* ChessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D4F28604D3700A486A4 /* ChessTests.swift */; };
 		D2BD8D5A28604D3700A486A4 /* ChessUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D5928604D3700A486A4 /* ChessUITests.swift */; };
 		D2BD8D5C28604D3700A486A4 /* ChessUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D5B28604D3700A486A4 /* ChessUITestsLaunchTests.swift */; };
+		D2BD8D6928604D7C00A486A4 /* Chess.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D6828604D7C00A486A4 /* Chess.swift */; };
+		D2BD8D6B2860742A00A486A4 /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2BD8D6A2860742A00A486A4 /* Piece.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +51,8 @@
 		D2BD8D5528604D3700A486A4 /* ChessUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2BD8D5928604D3700A486A4 /* ChessUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessUITests.swift; sourceTree = "<group>"; };
 		D2BD8D5B28604D3700A486A4 /* ChessUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		D2BD8D6828604D7C00A486A4 /* Chess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chess.swift; sourceTree = "<group>"; };
+		D2BD8D6A2860742A00A486A4 /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +103,8 @@
 		D2BD8D3728604D3600A486A4 /* Chess */ = {
 			isa = PBXGroup;
 			children = (
+				D2BD8D6828604D7C00A486A4 /* Chess.swift */,
+				D2BD8D6A2860742A00A486A4 /* Piece.swift */,
 				D2BD8D3828604D3600A486A4 /* AppDelegate.swift */,
 				D2BD8D3A28604D3600A486A4 /* SceneDelegate.swift */,
 				D2BD8D3C28604D3600A486A4 /* ViewController.swift */,
@@ -258,7 +264,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2BD8D6928604D7C00A486A4 /* Chess.swift in Sources */,
 				D2BD8D3D28604D3600A486A4 /* ViewController.swift in Sources */,
+				D2BD8D6B2860742A00A486A4 /* Piece.swift in Sources */,
 				D2BD8D3928604D3600A486A4 /* AppDelegate.swift in Sources */,
 				D2BD8D3B28604D3600A486A4 /* SceneDelegate.swift in Sources */,
 			);

--- a/Chess/Chess.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Chess/Chess.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Chess/Chess.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Chess/Chess.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Chess/Chess/AppDelegate.swift
+++ b/Chess/Chess/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  Chess
+//
+//  Created by Hailey on 2022/06/20.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Chess/Chess/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Chess/Chess/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Chess/Chess/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Chess/Chess/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Chess/Chess/Assets.xcassets/Contents.json
+++ b/Chess/Chess/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Chess/Chess/Base.lproj/LaunchScreen.storyboard
+++ b/Chess/Chess/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Chess/Chess/Base.lproj/Main.storyboard
+++ b/Chess/Chess/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Chess/Chess/Chess.swift
+++ b/Chess/Chess/Chess.swift
@@ -6,3 +6,41 @@
 //
 
 import Foundation
+struct Point: Equatable {
+
+    var y: Int
+    var x: Int
+    
+    init(point: String) {
+        self.y = (Int(String(point.last ?? "0")) ?? 0) - 1
+        self.x = Int((UnicodeScalar(String(point.first ?? "0"))?.value ?? 0) - 65)
+    }
+    
+    func checkIndexOutOfRange(y: Int, x: Int) -> Bool {
+        if 0 <= x && x < 8 && 0 <= y && y < 8 {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    func convertToString() -> String {
+        if let xString = UnicodeScalar(x + 65) {
+            let yString = "\(y + 1)"
+            return "\(String(describing: xString))\(yString)"
+        } else {
+            return ""
+        }
+    }
+    
+    mutating func move(offsetX: Int, offsetY: Int) -> Bool {
+        let nx = x + offsetX
+        let ny = y + offsetY
+        
+        guard checkIndexOutOfRange(y: ny, x: nx) else { return false }
+        
+        self.x = nx
+        self.y = ny
+        return true
+    }
+}

--- a/Chess/Chess/Chess.swift
+++ b/Chess/Chess/Chess.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 struct Point: Equatable {
 
     var y: Int
@@ -42,5 +43,122 @@ struct Point: Equatable {
         self.x = nx
         self.y = ny
         return true
+    }
+}
+
+class Chess {
+
+    private var board = [[Piece]](repeating: Array(repeating: Piece(color: .none, type: .none),count: 8), count: 8)
+    private var turn: Color = .white
+    
+    init() {
+        reset()
+    }
+    
+    func reset() {
+        let order: [PieceType] = [.luke, .knight, .bishop, .none, .queen, .bishop, .knight, .luke]
+        
+        for rank in 0..<8 {
+            board[0][rank] = Piece(color: .black, type: order[rank])
+            board[1][rank] = Piece(color: .black, type: .pawn)
+            board[6][rank] = Piece(color: .white, type: .pawn)
+            board[7][rank] = Piece(color: .white, type: order[rank])
+        }
+    }
+    
+    func display() -> String {
+        var result = ""
+
+        for file in 0..<8 {
+            result += board[file].flatMap { $0.mark }
+            result += file < 7 ? "\n" : ""
+        }
+        
+        return result
+    }
+    
+    func showGuide(command: String) -> [String] {
+        let startPoint: Point = Point(point: String(command.suffix(2)))
+        let piece = board[startPoint.y][startPoint.x]
+        
+        // 말이 갈 수 있는 포인트 중 막히지 않은 칸만 필터링
+        let possiblePoints = piece.getPossiblePoints(startPoint: startPoint).filter { check(from: startPoint, to: $0) && checkEndpoint(point: $0) }
+        let convertedPoints = possiblePoints.map { $0.convertToString() } // rank, file 형식으로 변형
+        return convertedPoints
+    }
+    
+    func action(command: String) -> Bool {
+        let startPoint: Point = Point(point: String(command.prefix(2)))
+        let endPoint: Point = Point(point: String(command.suffix(2)))
+        
+        // 해당 타입의 말의 이동방식으로 갈 수있는 칸인지 검사 && 도착지까지의 루트에 아군말이 있는지 검사
+        let isAvailable = check(from: startPoint, to: endPoint)
+        
+        // 말 이동
+        if isAvailable {
+            move(from: startPoint, to: endPoint)
+        }
+        
+        // 턴 넘기기
+        turn = turn == .white ? .black : .white
+
+        return isAvailable
+    }
+    
+    func check(from startPoint: Point, to endPoint: Point) -> Bool {
+        // 해당 타입의 말의 이동방식으로 갈 수있는 칸인지 검사
+        var isAvailable = board[startPoint.y][startPoint.x].checkMoving(from: startPoint, to: endPoint)
+        // 도착지 전까지의 루트에 말이 있는지 검사 (아군/적군 있으면 이동 불가)
+        isAvailable = checkRoute(from: startPoint, to: endPoint)
+        // 도착지 상태 확인 (빈칸 / 아군 / 적군)
+        isAvailable = checkEndpoint(point: endPoint)
+        return isAvailable
+    }
+
+    // 도착지 상태 확인 (빈칸 / 아군 / 적군)
+    func checkEndpoint(point: Point) -> Bool {
+        var isAvailable: Bool
+        
+        let previousPiece: Piece = board[point.y][point.x]
+        
+        if previousPiece.type == .none { // 빈 칸
+            isAvailable = true
+        } else if previousPiece.color == turn { // 아군 말
+            isAvailable = false
+        } else { // 적군 말
+            isAvailable = true
+            print(showScore())
+        }
+        
+        return isAvailable
+    }
+    
+    // 도착지 전까지의 루트에 말이 있는지 검사 (아군/적군 있으면 이동 불가)
+    func checkRoute(from startPoint: Point, to endPoint: Point) -> Bool {
+        var isAvailable: Bool = true
+        let piece = board[startPoint.y][startPoint.x]
+        let route = piece.getRoute(from: startPoint, to: endPoint)
+        
+        route.forEach { point in
+            if board[point.y][point.x].type != .none {
+                isAvailable = false
+                return
+            }
+        }
+        
+        return isAvailable
+    }
+
+    func move(from startPoint: Point, to endPoint: Point) {
+        board[endPoint.y][endPoint.x] = board[startPoint.y][startPoint.x]
+        board[startPoint.y][startPoint.x] = Piece(color: .none, type: .none)
+    }
+    
+    func showScore() -> (Int, Int) {
+        let flattenedArray = board.flatMap { $0 }
+        let whiteScore = flattenedArray.filter { $0.color == .white }.map { $0.type.score }.reduce(0, +)
+        let blackScore = flattenedArray.filter { $0.color == .black }.map { $0.type.score }.reduce(0, +)
+        
+        return (whiteScore, blackScore)
     }
 }

--- a/Chess/Chess/Chess.swift
+++ b/Chess/Chess/Chess.swift
@@ -1,0 +1,8 @@
+//
+//  Chess.swift
+//  Chess
+//
+//  Created by Hailey on 2022/06/20.
+//
+
+import Foundation

--- a/Chess/Chess/Info.plist
+++ b/Chess/Chess/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Chess/Chess/Piece.swift
+++ b/Chess/Chess/Piece.swift
@@ -1,0 +1,8 @@
+//
+//  Piece.swift
+//  Chess
+//
+//  Created by Hailey on 2022/06/20.
+//
+
+import Foundation

--- a/Chess/Chess/Piece.swift
+++ b/Chess/Chess/Piece.swift
@@ -5,4 +5,153 @@
 //  Created by Hailey on 2022/06/20.
 //
 
-import Foundation
+enum Color {
+    case black, white, none
+}
+
+enum PieceType {
+    case pawn
+    case knight
+    case bishop
+    case luke
+    case queen
+    case none
+    
+    var score: Int {
+        switch self {
+        case .pawn:
+            return 1
+        case .knight:
+            return 3
+        case .bishop:
+            return 3
+        case .luke:
+            return 5
+        case .queen:
+            return 9
+        case .none:
+            return 0
+        }
+    }
+    
+    var moveLimit: Int { // 폰인 경우 한 번만 이동하도록
+        if self == .pawn {
+            return 1
+        } else {
+            return 7
+        }
+    }
+    
+    var getOffsetX: [Int] {
+        switch self {
+        case .pawn:
+            return [0]
+        case .knight:
+            return []
+        case .bishop:
+            return [-1, -1, 1, 1]
+        case .luke:
+            return [-1, 0, 1, 0]
+        case .queen:
+            return []
+        case .none:
+            return []
+        }
+    }
+    
+    func getOffsetY(color: Color) -> [Int] {
+        switch self {
+        case .pawn:
+            // 화이트폰과 블랙폰의 방향이 다르므로
+            if color == .white {
+                return [-1]
+            } else {
+                return [1]
+            }
+        case .knight:
+            return []
+        case .bishop:
+            return [-1, 1, -1, 1]
+        case .luke:
+            return [0, -1, 0, 1]
+        case .queen:
+            return []
+        case .none:
+            return []
+        }
+    }
+}
+
+class Piece {
+
+    var color: Color = .none
+    var type: PieceType = .none
+    
+    lazy var mark: String = {
+        switch type {
+        case .pawn:
+            return color == .white ? "\u{2659}" : "\u{265F}"
+        case .knight:
+            return color == .white ? "\u{2658}" : "\u{265E}"
+        case .bishop:
+            return color == .white ? "\u{2657}" : "\u{265D}"
+        case .luke:
+            return color == .white ? "\u{2656}" : "\u{265C}"
+        case .queen:
+            return color == .white ? "\u{2655}" : "\u{265B}"
+        case .none:
+            return "."
+        }
+    }()
+
+    init(color: Color, type: PieceType) {
+        self.color = color
+        self.type = type
+    }
+    
+    // 갈 수 있는 모든 칸 찾기 (현재 보드판 상황과 무관)
+    func getPossiblePoints(startPoint: Point) -> [Point] {
+        var possiblePoints: [Point] = []
+        let count = max(type.getOffsetX.count, type.getOffsetY(color: color).count) // 말이 갈 수 있는 방향 개수
+        
+        for index in 0..<count { // 각 방향마다 탐색
+            var nextPosition = startPoint
+            
+            for _ in 0..<type.moveLimit {
+                guard nextPosition.move(offsetX: type.getOffsetX[index], offsetY: type.getOffsetY(color: color)[index]) else { break }
+                possiblePoints.append(nextPosition)
+            }
+        }
+        
+        return possiblePoints
+    }
+    
+    // 해당 타입의 말이 갈 수 있는 칸(도착지)인지 검사
+    func checkMoving(from startPoint: Point, to endPoint: Point) -> Bool {
+        let possiblePoints: [Point] = getPossiblePoints(startPoint: startPoint)
+        return possiblePoints.contains(endPoint)
+    }
+    
+    // 도착지까지의 경로 찾기
+    func getRoute(from startPoint: Point, to endPoint: Point) -> [Point] {
+        var route: [Point] = []
+
+        let offsetY = startPoint.y - endPoint.y
+        let directionY = offsetY / abs(offsetY)
+
+        let offsetX = startPoint.x - endPoint.x
+        let directionX = offsetX / abs(offsetX)
+        
+        var nextPoint = startPoint
+        
+        while(nextPoint != endPoint) {
+            guard nextPoint.move(offsetX: directionY, offsetY: directionX) else { break }
+
+            if nextPoint != endPoint {
+                route.append(nextPoint)
+            }            
+        }
+        
+        return route
+    }
+}

--- a/Chess/Chess/SceneDelegate.swift
+++ b/Chess/Chess/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  Chess
+//
+//  Created by Hailey on 2022/06/20.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/Chess/Chess/ViewController.swift
+++ b/Chess/Chess/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  Chess
+//
+//  Created by Hailey on 2022/06/20.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/Chess/ChessTests/ChessTests.swift
+++ b/Chess/ChessTests/ChessTests.swift
@@ -1,0 +1,36 @@
+//
+//  ChessTests.swift
+//  ChessTests
+//
+//  Created by Hailey on 2022/06/20.
+//
+
+import XCTest
+@testable import Chess
+
+class ChessTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Chess/ChessUITests/ChessUITests.swift
+++ b/Chess/ChessUITests/ChessUITests.swift
@@ -1,0 +1,42 @@
+//
+//  ChessUITests.swift
+//  ChessUITests
+//
+//  Created by Hailey on 2022/06/20.
+//
+
+import XCTest
+
+class ChessUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/Chess/ChessUITests/ChessUITestsLaunchTests.swift
+++ b/Chess/ChessUITests/ChessUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  ChessUITestsLaunchTests.swift
+//  ChessUITests
+//
+//  Created by Hailey on 2022/06/20.
+//
+
+import XCTest
+
+class ChessUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
안녕하세요 JK,
PR이 늦어서 죄송합니다.

** 코드 설명 **
![카카오 2022-21](https://user-images.githubusercontent.com/65452512/176254934-8aa293be-682d-4612-8d54-29185378a5b0.jpg)

저는 아직 디자인 패턴은 적용하지 않았고, 
체스 게임 내부 동작을 최대한 자동화 시켜서 UI단에서는 비즈니스 로직이 없도록 구현해보았습니다.

- 체스판은 UICollectionView를 이용하여 그리도록 했습니다.
- indexPath.row와 Point 간의 변환 메서드도 추가했습니다.
- 뷰 컨트롤러에서 ChessDelegate를 채택한 후 Chess에서 delegate 메서드를 호출해 필요한 UI 업데이트를 하도록 구현했습니다.
- Piece에 isCandidate 프로퍼티를 추가해 board를 참조하여 얻은 값을 통해 collectionView(cellForItemAt:)에서 별도의 분기처리 없이 해당 프로퍼티의 값만 보고 칸의 색상을 결정할 수 있도록 했습니다.
- collectionView(didSelectItemAt:)에서는 Chess의 selectPoint를 호출해 Chess에서 내부적으로 현재 단계에 맞는 동작을 하도록 한 뒤 delegate 메서드를 호출하도록 했습니다.
- 또한, 페어 프로그래밍을 통해 파트너가 예외처리를 활용 하시는 습관을 보고 좋다고 생각해서 어설프지만 ChessError와 PointError를 만들어서 예외처리를 활용해보았습니다.

** 이전 PR에 대한 답변**
1. Color나 PieceType에 .none 항목이 있는데 둘 다 none을 두는 방식을 선택하신 이유가 궁금합니다.
- .none을 빈 칸의 값으로 생각하고 추가했습니다.
- 제가 생각했던 다른 방법으로는 board의 타입을 [[Piece?]]로 두는 방법과 Piece의 color나 type을 옵셔널로 설정하는 방법이 있습니다.
- 하지만 그렇게 할 경우 매번 불필요하게 옵셔널을 언래핑해야 한다고 느껴져서 전자의 방법을 선택했습니다..!

2. PieceType과 Piece를 각각 만든 이유
- 우선, 서브클래싱 대신 enum을 사용한 이유는 서브클래싱을 통해 중복 코드들이 발생하는 것보다 분기처리를 통해 구현하는 것이 더 경제적이라고 생각했습니다.
- PieecType과 Piece를 각각 만든 이유는 Piece에서 사용하는 type에 대해 구분할 수 있는 기준이 필요해서입니다.
- 하지만 이번 주 강의를 듣고 나서 객체지향적 관점을 적용해보도록 수정하는 걸 추후 과제로 설정하면 좋겠다고 생각했습니다 ☺️

그리고 혹시 단위 테스트에 대해 궁금한 것을 여쭤보아도 될까요?
메서드의 접근지정자를 private 등으로 설정하면 단위테스트에서 해당 메서드에 접근할 수가 없게 되는데요,
이 경우에는 테스트 후에 접근지정자를 설정하는 방식으로 해야할까요?