### PR TITLE
체스말 이동로직 추가

### DIFF
--- a/Swift-Chessgame/Swift-Chessgame.xcodeproj/project.pbxproj
+++ b/Swift-Chessgame/Swift-Chessgame.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		363A32CE286050860077655A /* BoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363A32CD286050860077655A /* BoardTests.swift */; };
 		363A32D12860523F0077655A /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363A32D02860523F0077655A /* Board.swift */; };
 		363A32D328607B440077655A /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363A32D228607B440077655A /* Piece.swift */; };
+		366D1324286987B1009FC965 /* PieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 366D1323286987B1009FC965 /* PieceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +42,7 @@
 		363A32CD286050860077655A /* BoardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTests.swift; sourceTree = "<group>"; };
 		363A32D02860523F0077655A /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		363A32D228607B440077655A /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
+		366D1323286987B1009FC965 /* PieceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +100,7 @@
 			isa = PBXGroup;
 			children = (
 				363A32CD286050860077655A /* BoardTests.swift */,
+				366D1323286987B1009FC965 /* PieceTests.swift */,
 			);
 			path = "Swift-ChessgameTests";
 			sourceTree = "<group>";
@@ -224,6 +227,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				366D1324286987B1009FC965 /* PieceTests.swift in Sources */,
 				363A32CE286050860077655A /* BoardTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
@@ -15,29 +15,29 @@ class Board {
     init() {
         var pieces = [[PieceType?]]()
         
-        for rank in 1...8 {
-            let team: Team = (rank == 1 || rank == 2) ? .white : .black
+        for file in ChessPosition.File.allCases {
+            let team: Team = (file == .one || file == .two) ? .white : .black
             
-            let isPawnRank = rank == 2 || rank == 7
-            if isPawnRank {
-                let pawnRank = "ABCDEFGH".map { file in
-                    return Pawn(team: team, position: .init(rank: rank, file: "\(file)"))
+            let isPawnRow = file == .two || file == .seven
+            if isPawnRow {
+                let pawnRow = ChessPosition.Rank.allCases.map { rank in
+                    return Pawn(team: team, position: ChessPosition(row: file, column: rank))
                 }
-                pieces.append(pawnRank)
+                pieces.append(pawnRow)
                 continue
             }
             
-            let isFirstRankOfEachTeam = rank == 1 || rank == 8
+            let isFirstRankOfEachTeam = file == .one || file == .eight
             if isFirstRankOfEachTeam {
                 pieces.append([
-                    Luke(team: team, position: Position(rank: rank, file: "A")),
-                    Knight(team: team, position: Position(rank: rank, file: "B")),
-                    Bishop(team: team, position: Position(rank: rank, file: "C")),
+                    Luke(team: team, position: ChessPosition(row: file, column: .a)),
+                    Knight(team: team, position: ChessPosition(row: file, column: .b)),
+                    Bishop(team: team, position: ChessPosition(row: file, column: .c)),
                     nil,
-                    Queen(team: team, position: Position(rank: rank, file: "E")),
-                    Bishop(team: team, position: Position(rank: rank, file: "F")),
-                    Knight(team: team, position: Position(rank: rank, file: "G")),
-                    Luke(team: team, position: Position(rank: rank, file: "H"))
+                    Queen(team: team, position: ChessPosition(row: file, column: .e)),
+                    Bishop(team: team, position: ChessPosition(row: file, column: .f)),
+                    Knight(team: team, position: ChessPosition(row: file, column: .g)),
+                    Luke(team: team, position: ChessPosition(row: file, column: .h))
                 ])
                 continue
             }
@@ -48,10 +48,7 @@ class Board {
         self.pieces = pieces
     }
     
-    func findPiece(at position: Position) -> PieceType? {
-        if position.rankIndex < self.pieces.count, let fileIndex = position.fileIndex {
-            return self.pieces[position.rankIndex][fileIndex]
-        }
-        return nil
+    func findPiece(at position: ChessPosition) -> PieceType? {
+        return self.pieces[position.row.rawValue][position.column.rawValue]
     }
 }

--- a/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
@@ -59,7 +59,9 @@ class Board {
         return false
     }
 
-    func display() {
-        // TODO: 1-rank부터 8-rank까지 rank 문자열 배열로 보드 위에 체스말을 리턴
+    func display() -> String {
+        return self.pieces.map { row in
+            return row.reduce("", { $0 + ($1?.displayModel.displayString ?? ".") })
+        }.joined(separator: "\n")
     }
 }

--- a/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
@@ -12,6 +12,9 @@ class Board {
     
     private var pieces: [[PieceType?]]
     
+    private(set) var whiteScore = 0
+    private(set) var blackScore = 0
+    
     init() {
         var pieces = [[PieceType?]]()
         
@@ -50,5 +53,13 @@ class Board {
     
     func findPiece(at position: ChessPosition) -> PieceType? {
         return self.pieces[position.row.rawValue][position.column.rawValue]
+    }
+    
+    func movePiece(from curr: ChessPosition, to dest: ChessPosition) -> Bool {
+        return false
+    }
+
+    func display() {
+        // TODO: 1-rank부터 8-rank까지 rank 문자열 배열로 보드 위에 체스말을 리턴
     }
 }

--- a/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
@@ -33,14 +33,14 @@ class Board {
             let isFirstRankOfEachTeam = file == .one || file == .eight
             if isFirstRankOfEachTeam {
                 pieces.append([
-                    Luke(team: team, position: ChessPosition(row: file, column: .a)),
+                    Rook(team: team, position: ChessPosition(row: file, column: .a)),
                     Knight(team: team, position: ChessPosition(row: file, column: .b)),
                     Bishop(team: team, position: ChessPosition(row: file, column: .c)),
                     nil,
                     Queen(team: team, position: ChessPosition(row: file, column: .e)),
                     Bishop(team: team, position: ChessPosition(row: file, column: .f)),
                     Knight(team: team, position: ChessPosition(row: file, column: .g)),
-                    Luke(team: team, position: ChessPosition(row: file, column: .h))
+                    Rook(team: team, position: ChessPosition(row: file, column: .h))
                 ])
                 continue
             }

--- a/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Board.swift
@@ -24,7 +24,7 @@ class Board {
             let isPawnRow = file == .two || file == .seven
             if isPawnRow {
                 let pawnRow = ChessPosition.Rank.allCases.map { rank in
-                    return Pawn(team: team, position: ChessPosition(row: file, column: rank))
+                    return Pawn(team: team)
                 }
                 pieces.append(pawnRow)
                 continue
@@ -33,14 +33,14 @@ class Board {
             let isFirstRankOfEachTeam = file == .one || file == .eight
             if isFirstRankOfEachTeam {
                 pieces.append([
-                    Rook(team: team, position: ChessPosition(row: file, column: .a)),
-                    Knight(team: team, position: ChessPosition(row: file, column: .b)),
-                    Bishop(team: team, position: ChessPosition(row: file, column: .c)),
+                    Rook(team: team),
+                    Knight(team: team),
+                    Bishop(team: team),
                     nil,
-                    Queen(team: team, position: ChessPosition(row: file, column: .e)),
-                    Bishop(team: team, position: ChessPosition(row: file, column: .f)),
-                    Knight(team: team, position: ChessPosition(row: file, column: .g)),
-                    Rook(team: team, position: ChessPosition(row: file, column: .h))
+                    Queen(team: team),
+                    Bishop(team: team),
+                    Knight(team: team),
+                    Rook(team: team)
                 ])
                 continue
             }
@@ -51,11 +51,19 @@ class Board {
         self.pieces = pieces
     }
     
-    func findPiece(at position: ChessPosition) -> PieceType? {
-        return self.pieces[position.row.rawValue][position.column.rawValue]
+    func movablePositions(at position: ChessPosition) -> [ChessPosition] {
+        // TODO: 
+        return []
+    }
+    
+    private func isMovableRoute(_ route: PieceRoute) -> Bool {
+        return route.step
+            .filter({ self.pieces[$0] != nil })
+            .isEmpty
     }
     
     func movePiece(from curr: ChessPosition, to dest: ChessPosition) -> Bool {
+        // TODO:
         return false
     }
 
@@ -63,5 +71,16 @@ class Board {
         return self.pieces.map { row in
             return row.reduce("", { $0 + ($1?.displayModel.displayString ?? ".") })
         }.joined(separator: "\n")
+    }
+}
+
+private extension Array where Element == [PieceType?] {
+    
+    subscript (_ position: ChessPosition) -> PieceType? {
+        if let piece = self[position.row.rawValue][position.column.rawValue] {
+            return piece
+        } else {
+            return nil
+        }
     }
 }

--- a/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
@@ -12,24 +12,20 @@ protocol PieceType {
     
     var team: Team { get }
     var score: Int { get }
-    var position: Position { get set }
+    var position: ChessPosition { get set }
 }
 
-struct Position {
+struct ChessPosition {
     
-    var rank: Int
-    var file: String
+    var row: File
+    var column: Rank
     
-    var rankIndex: Int {
-        return rank - 1
+    enum File: Int, CaseIterable {
+        case one = 0, two, three, four, five, six, seven, eight
     }
     
-    var fileIndex: Int? {
-        let validFiles = Array("ABCDEFGH")
-        if let index = validFiles.firstIndex(where: { "\($0)" == file }) {
-            return validFiles.distance(from: validFiles.startIndex, to: index)
-        }
-        return nil
+    enum Rank: Int, CaseIterable {
+        case a = 0, b, c, d, e, f, g, h
     }
 }
 
@@ -43,33 +39,33 @@ struct Pawn: PieceType {
     
     let team: Team
     let score = 1
-    var position: Position
+    var position: ChessPosition
 }
 
 struct Knight: PieceType {
     
     let team: Team
     let score = 3
-    var position: Position
+    var position: ChessPosition
 }
 
 struct Bishop: PieceType {
     
     let team: Team
     let score = 3
-    var position: Position
+    var position: ChessPosition
 }
 
 struct Luke: PieceType {
     
     let team: Team
     let score = 5
-    var position: Position
+    var position: ChessPosition
 }
 
 struct Queen: PieceType {
     
     let team: Team
     let score = 9
-    var position: Position
+    var position: ChessPosition
 }

--- a/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
@@ -12,7 +12,8 @@ protocol PieceType {
     
     var team: Team { get }
     var score: Int { get }
-    var position: ChessPosition { get set }
+    
+    func movablePositions() -> [ChessPosition]
 }
 
 struct ChessPosition {
@@ -40,6 +41,10 @@ struct Pawn: PieceType {
     let team: Team
     let score = 1
     var position: ChessPosition
+    
+    func movablePositions() -> [ChessPosition] {
+        return []
+    }
 }
 
 struct Knight: PieceType {
@@ -47,6 +52,10 @@ struct Knight: PieceType {
     let team: Team
     let score = 3
     var position: ChessPosition
+    
+    func movablePositions() -> [ChessPosition] {
+        return []
+    }
 }
 
 struct Bishop: PieceType {
@@ -54,6 +63,10 @@ struct Bishop: PieceType {
     let team: Team
     let score = 3
     var position: ChessPosition
+    
+    func movablePositions() -> [ChessPosition] {
+        return []
+    }
 }
 
 struct Luke: PieceType {
@@ -61,6 +74,10 @@ struct Luke: PieceType {
     let team: Team
     let score = 5
     var position: ChessPosition
+    
+    func movablePositions() -> [ChessPosition] {
+        return []
+    }
 }
 
 struct Queen: PieceType {
@@ -68,4 +85,8 @@ struct Queen: PieceType {
     let team: Team
     let score = 9
     var position: ChessPosition
+    
+    func movablePositions() -> [ChessPosition] {
+        return []
+    }
 }

--- a/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
@@ -14,7 +14,7 @@ protocol PieceType {
     var score: Int { get }
     var displayModel: PiecePresentation { get }
     
-    func movableRoute() -> [PieceRoute]
+    func movableRoute(at: ChessPosition) -> [PieceRoute]
 }
 
 enum Team {
@@ -137,10 +137,9 @@ struct Pawn: PieceType {
     
     let team: Team
     let score = 1
-    var position: ChessPosition
     
-    func movableRoute() -> [PieceRoute] {
-        let route = PieceRoute(position: self.position)
+    func movableRoute(at position: ChessPosition) -> [PieceRoute] {
+        let route = PieceRoute(position: position)
         if team == .black {
             return [
                 route.moveTo(.left),
@@ -168,10 +167,9 @@ struct Knight: PieceType {
     
     let team: Team
     let score = 3
-    var position: ChessPosition
     
-    func movableRoute() -> [PieceRoute] {
-        let route = PieceRoute(position: self.position)
+    func movableRoute(at position: ChessPosition) -> [PieceRoute] {
+        let route = PieceRoute(position: position)
         return [
             route.moveTo(.up)?.moveTo(.upperLeftDiagonal),
             route.moveTo(.up)?.moveTo(.upperRightDiagonal),
@@ -191,10 +189,9 @@ struct Bishop: PieceType {
     
     let team: Team
     let score = 3
-    var position: ChessPosition
     
-    func movableRoute() -> [PieceRoute] {
-        let route = PieceRoute(position: self.position)
+    func movableRoute(at position: ChessPosition) -> [PieceRoute] {
+        let route = PieceRoute(position: position)
         return [
             route.moveTo(.upperLeftDiagonal),
             route.moveTo(.upperRightDiagonal),
@@ -214,10 +211,9 @@ struct Rook: PieceType {
     
     let team: Team
     let score = 5
-    var position: ChessPosition
     
-    func movableRoute() -> [PieceRoute] {
-        let route = PieceRoute(position: self.position)
+    func movableRoute(at position: ChessPosition) -> [PieceRoute] {
+        let route = PieceRoute(position: position)
         return [
             route.moveTo(.up),
             route.moveTo(.left),
@@ -237,10 +233,9 @@ struct Queen: PieceType {
     
     let team: Team
     let score = 9
-    var position: ChessPosition
     
-    func movableRoute() -> [PieceRoute] {
-        let route = PieceRoute(position: self.position)
+    func movableRoute(at position: ChessPosition) -> [PieceRoute] {
+        let route = PieceRoute(position: position)
         return [
             route.moveTo(.up),
             route.moveTo(.upperLeftDiagonal),

--- a/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
@@ -16,7 +16,7 @@ protocol PieceType {
     func movablePositions() -> [ChessPosition]
 }
 
-struct ChessPosition {
+struct ChessPosition: Equatable {
     
     var row: File
     var column: Rank
@@ -27,6 +27,34 @@ struct ChessPosition {
     
     enum Rank: Int, CaseIterable {
         case a = 0, b, c, d, e, f, g, h
+    }
+    
+    func up() -> ChessPosition? {
+        guard let upRow = File(rawValue: self.row.rawValue - 1) else {
+            return nil
+        }
+        return ChessPosition(row: upRow, column: self.column)
+    }
+    
+    func down() -> ChessPosition? {
+        guard let downRow = File(rawValue: self.row.rawValue + 1) else {
+            return nil
+        }
+        return ChessPosition(row: downRow, column: self.column)
+    }
+    
+    func left() -> ChessPosition? {
+        guard let leftCol = Rank(rawValue: self.column.rawValue - 1) else {
+            return nil
+        }
+        return ChessPosition(row: self.row, column: leftCol)
+    }
+    
+    func right() -> ChessPosition? {
+        guard let rightCol = Rank(rawValue: self.column.rawValue + 1) else {
+            return nil
+        }
+        return ChessPosition(row: self.row, column: rightCol)
     }
 }
 
@@ -43,7 +71,12 @@ struct Pawn: PieceType {
     var position: ChessPosition
     
     func movablePositions() -> [ChessPosition] {
-        return []
+        return [
+            self.position.up(),
+            self.position.down(),
+            self.position.left(),
+            self.position.right()
+        ].compactMap { $0 }
     }
 }
 

--- a/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
@@ -12,8 +12,19 @@ protocol PieceType {
     
     var team: Team { get }
     var score: Int { get }
+    var displayModel: PiecePresentation { get }
     
     func movablePositions() -> [ChessPosition]
+}
+
+enum Team {
+    
+    case black
+    case white
+}
+
+struct PiecePresentation {
+    var displayString: String
 }
 
 struct ChessPosition: Equatable {
@@ -74,12 +85,6 @@ struct ChessPosition: Equatable {
     }
 }
 
-enum Team {
-    
-    case black
-    case white
-}
-
 struct Pawn: PieceType {
     
     let team: Team
@@ -92,6 +97,12 @@ struct Pawn: PieceType {
             self.position.left(),
             self.position.right()
         ].compactMap { $0 }
+    }
+    
+    var displayModel: PiecePresentation {
+        return PiecePresentation(
+            displayString: self.team == .white ? "\u{2659}" : "\u{265F}"
+        )
     }
 }
 
@@ -108,6 +119,12 @@ struct Knight: PieceType {
             self.position.down()?.bottomLeftDiagonal(),
             self.position.down()?.bottomRightDiagonal(),
         ].compactMap { $0 }
+    }
+    
+    var displayModel: PiecePresentation {
+        return PiecePresentation(
+            displayString: self.team == .white ? "\u{2658}" : "\u{265E}"
+        )
     }
 }
 
@@ -142,6 +159,12 @@ struct Bishop: PieceType {
         
         return movablePositions
     }
+    
+    var displayModel: PiecePresentation {
+        return PiecePresentation(
+            displayString: self.team == .white ? "\u{2657}" : "\u{265D}"
+        )
+    }
 }
 
 struct Rook: PieceType {
@@ -174,6 +197,12 @@ struct Rook: PieceType {
         }
         
         return movablePositions
+    }
+    
+    var displayModel: PiecePresentation {
+        return PiecePresentation(
+            displayString: self.team == .white ? "\u{2656}" : "\u{265C}"
+        )
     }
 }
 
@@ -227,5 +256,11 @@ struct Queen: PieceType {
         }
         
         return movablePositions
+    }
+    
+    var displayModel: PiecePresentation {
+        return PiecePresentation(
+            displayString: self.team == .white ? "\u{2655}" : "\u{265B}"
+        )
     }
 }

--- a/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
@@ -102,7 +102,7 @@ struct Bishop: PieceType {
     }
 }
 
-struct Luke: PieceType {
+struct Rook: PieceType {
     
     let team: Team
     let score = 5

--- a/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
+++ b/Swift-Chessgame/Swift-Chessgame/Model/Piece.swift
@@ -56,6 +56,22 @@ struct ChessPosition: Equatable {
         }
         return ChessPosition(row: self.row, column: rightCol)
     }
+    
+    func upperLeftDiagonal() -> ChessPosition? {
+        return self.up()?.left()
+    }
+    
+    func upperRightDiagonal() -> ChessPosition? {
+        return self.up()?.right()
+    }
+    
+    func bottomLeftDiagonal() -> ChessPosition? {
+        return self.down()?.left()
+    }
+    
+    func bottomRightDiagonal() -> ChessPosition? {
+        return self.down()?.right()
+    }
 }
 
 enum Team {
@@ -72,8 +88,7 @@ struct Pawn: PieceType {
     
     func movablePositions() -> [ChessPosition] {
         return [
-            self.position.up(),
-            self.position.down(),
+            team == .white ? self.position.down() : self.position.up(),
             self.position.left(),
             self.position.right()
         ].compactMap { $0 }
@@ -87,7 +102,12 @@ struct Knight: PieceType {
     var position: ChessPosition
     
     func movablePositions() -> [ChessPosition] {
-        return []
+        return [
+            self.position.up()?.upperRightDiagonal(),
+            self.position.up()?.upperLeftDiagonal(),
+            self.position.down()?.bottomLeftDiagonal(),
+            self.position.down()?.bottomRightDiagonal(),
+        ].compactMap { $0 }
     }
 }
 
@@ -98,7 +118,29 @@ struct Bishop: PieceType {
     var position: ChessPosition
     
     func movablePositions() -> [ChessPosition] {
-        return []
+        var movablePositions = [ChessPosition]()
+        
+        var current = self.position
+        while let next = current.upperRightDiagonal() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.upperLeftDiagonal() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.bottomRightDiagonal() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.bottomLeftDiagonal() {
+            movablePositions.append(next)
+        }
+        
+        return movablePositions
     }
 }
 
@@ -109,7 +151,29 @@ struct Rook: PieceType {
     var position: ChessPosition
     
     func movablePositions() -> [ChessPosition] {
-        return []
+        var movablePositions = [ChessPosition]()
+        
+        var current = self.position
+        while let next = current.up() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.down() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.left() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.right() {
+            movablePositions.append(next)
+        }
+        
+        return movablePositions
     }
 }
 
@@ -120,6 +184,48 @@ struct Queen: PieceType {
     var position: ChessPosition
     
     func movablePositions() -> [ChessPosition] {
-        return []
+        var movablePositions = [ChessPosition]()
+        
+        var current = self.position
+        while let next = current.upperRightDiagonal() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.upperLeftDiagonal() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.bottomRightDiagonal() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.bottomLeftDiagonal() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.up() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.down() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.left() {
+            movablePositions.append(next)
+        }
+        
+        current = self.position
+        while let next = current.right() {
+            movablePositions.append(next)
+        }
+        
+        return movablePositions
     }
 }

--- a/Swift-Chessgame/Swift-ChessgameTests/BoardTests.swift
+++ b/Swift-Chessgame/Swift-ChessgameTests/BoardTests.swift
@@ -23,13 +23,12 @@ class BoardTests: XCTestCase {
     
     func test_empty_pieces_when_init_board() {
         // given
-        let emptyRanks = [3, 4, 5, 6]
-        let files = "ABCDEFGH"
+        let emptyFiles: [ChessPosition.File] = [.three, .four, .five, .six]
         
         // then
-        for rank in emptyRanks {
-            for file in files {
-                let piece = self.sut.findPiece(at: Position(rank: rank, file: String(file)))
+        for file in emptyFiles {
+            ChessPosition.Rank.allCases.forEach { rank in
+                let piece = self.sut.findPiece(at: ChessPosition(row: file, column: rank))
                 XCTAssertNil(piece)
             }
         }
@@ -37,13 +36,12 @@ class BoardTests: XCTestCase {
     
     func test_pawn_when_init_board() {
         // given
-        let pawnRanks = [2, 7]
-        let files = "ABCDEFGH"
+        let pawnFiles: [ChessPosition.File] = [.two, .seven]
         
         // then
-        for rank in pawnRanks {
-            for file in files {
-                let piece = self.sut.findPiece(at: Position(rank: rank, file: String(file)))
+        for file in pawnFiles {
+            ChessPosition.Rank.allCases.forEach { rank in
+                let piece = self.sut.findPiece(at: ChessPosition(row: file, column: rank))
                 XCTAssertNotNil(piece as? Pawn)
             }
         }
@@ -52,12 +50,12 @@ class BoardTests: XCTestCase {
     func test_luke_when_init_board() {
         // given
         let whiteLukes = [
-            self.sut.findPiece(at: Position(rank: 1, file: "A")),
-            self.sut.findPiece(at: Position(rank: 1, file: "H")),
+            self.sut.findPiece(at: ChessPosition(row: .one, column: .a)),
+            self.sut.findPiece(at: ChessPosition(row: .one, column: .h)),
         ]
         let blackLukes = [
-            self.sut.findPiece(at: Position(rank: 8, file: "A")),
-            self.sut.findPiece(at: Position(rank: 8, file: "H")),
+            self.sut.findPiece(at: ChessPosition(row: .eight, column: .a)),
+            self.sut.findPiece(at: ChessPosition(row: .eight, column: .h))
         ]
         
         // then
@@ -77,12 +75,12 @@ class BoardTests: XCTestCase {
     func test_knight_when_init_board() {
         // given
         let whiteKnights = [
-            self.sut.findPiece(at: Position(rank: 1, file: "B")),
-            self.sut.findPiece(at: Position(rank: 1, file: "G")),
+            self.sut.findPiece(at: ChessPosition(row: .one, column: .b)),
+            self.sut.findPiece(at: ChessPosition(row: .one, column: .g)),
         ]
         let blackKnights = [
-            self.sut.findPiece(at: Position(rank: 8, file: "B")),
-            self.sut.findPiece(at: Position(rank: 8, file: "G")),
+            self.sut.findPiece(at: ChessPosition(row: .eight, column: .b)),
+            self.sut.findPiece(at: ChessPosition(row: .eight, column: .g)),
         ]
         
         // then
@@ -102,12 +100,12 @@ class BoardTests: XCTestCase {
     func test_bishop_when_init_board() {
         // given
         let whiteBishops = [
-            self.sut.findPiece(at: Position(rank: 1, file: "C")),
-            self.sut.findPiece(at: Position(rank: 1, file: "F")),
+            self.sut.findPiece(at: ChessPosition(row: .one, column: .c)),
+            self.sut.findPiece(at: ChessPosition(row: .one, column: .f)),
         ]
         let blackBishops = [
-            self.sut.findPiece(at: Position(rank: 8, file: "C")),
-            self.sut.findPiece(at: Position(rank: 8, file: "F")),
+            self.sut.findPiece(at: ChessPosition(row: .eight, column: .c)),
+            self.sut.findPiece(at: ChessPosition(row: .eight, column: .f))
         ]
         
         // then
@@ -126,8 +124,8 @@ class BoardTests: XCTestCase {
     
     func test_queen_when_init_board() {
         // given
-        let whiteQueen = self.sut.findPiece(at: Position(rank: 1, file: "E"))
-        let blackQueen = self.sut.findPiece(at: Position(rank: 8, file: "E"))
+        let whiteQueen = self.sut.findPiece(at: ChessPosition(row: .one, column: .e))
+        let blackQueen = self.sut.findPiece(at: ChessPosition(row: .eight, column: .e))
         
         // then
         XCTAssertNotNil(whiteQueen as? Queen)

--- a/Swift-Chessgame/Swift-ChessgameTests/BoardTests.swift
+++ b/Swift-Chessgame/Swift-ChessgameTests/BoardTests.swift
@@ -134,4 +134,23 @@ class BoardTests: XCTestCase {
         XCTAssertNotNil(blackQueen as? Queen)
         XCTAssertEqual(blackQueen?.team, .black)
     }
+    
+    func test_display_init_board() {
+        // when
+        let displayString = self.sut.display()
+        
+        // then
+        XCTAssertEqual(displayString,
+            """
+            ♖♘♗.♕♗♘♖
+            ♙♙♙♙♙♙♙♙
+            ........
+            ........
+            ........
+            ........
+            ♟♟♟♟♟♟♟♟
+            ♜♞♝.♛♝♞♜
+            """
+        )
+    }
 }

--- a/Swift-Chessgame/Swift-ChessgameTests/BoardTests.swift
+++ b/Swift-Chessgame/Swift-ChessgameTests/BoardTests.swift
@@ -47,28 +47,28 @@ class BoardTests: XCTestCase {
         }
     }
     
-    func test_luke_when_init_board() {
+    func test_rook_when_init_board() {
         // given
-        let whiteLukes = [
+        let whiteRooks = [
             self.sut.findPiece(at: ChessPosition(row: .one, column: .a)),
             self.sut.findPiece(at: ChessPosition(row: .one, column: .h)),
         ]
-        let blackLukes = [
+        let blackRooks = [
             self.sut.findPiece(at: ChessPosition(row: .eight, column: .a)),
             self.sut.findPiece(at: ChessPosition(row: .eight, column: .h))
         ]
         
         // then
-        whiteLukes.forEach { piece in
-            let luke = piece as? Luke
-            XCTAssertNotNil(luke)
-            XCTAssertEqual(luke?.team, .white)
+        whiteRooks.forEach { piece in
+            let rook = piece as? Rook
+            XCTAssertNotNil(rook)
+            XCTAssertEqual(rook?.team, .white)
         }
         
-        blackLukes.forEach { piece in
-            let luke = piece as? Luke
-            XCTAssertNotNil(luke)
-            XCTAssertEqual(luke?.team, .black)
+        blackRooks.forEach { piece in
+            let rook = piece as? Rook
+            XCTAssertNotNil(rook)
+            XCTAssertEqual(rook?.team, .black)
         }
     }
     

--- a/Swift-Chessgame/Swift-ChessgameTests/PieceTests.swift
+++ b/Swift-Chessgame/Swift-ChessgameTests/PieceTests.swift
@@ -21,10 +21,10 @@ class PieceTests: XCTestCase {
     
     func test_black_pawn_movableRoute() {
         // given
-        let pawn = Pawn(team: .black, position: .init(row: .two, column: .b))
+        let pawn = Pawn(team: .black)
         
         // then
-        XCTAssertEqual(pawn.movableRoute().map { $0.step }, [
+        XCTAssertEqual(pawn.movableRoute(at: .init(row: .two, column: .b)).map { $0.step }, [
             [ChessPosition(row: .two, column: .a)],
             [ChessPosition(row: .three, column: .b)],
             [ChessPosition(row: .two, column: .c)]
@@ -33,10 +33,10 @@ class PieceTests: XCTestCase {
     
     func test_white_pawn_movableRoute() {
         // given
-        let pawn = Pawn(team: .white, position: .init(row: .seven, column: .b))
+        let pawn = Pawn(team: .white)
         
         // then
-        XCTAssertEqual(pawn.movableRoute().map { $0.step }, [
+        XCTAssertEqual(pawn.movableRoute(at: .init(row: .seven, column: .b)).map { $0.step }, [
             [ChessPosition(row: .six, column: .b)],
             [ChessPosition(row: .seven, column: .a)],
             [ChessPosition(row: .seven, column: .c)]
@@ -45,11 +45,11 @@ class PieceTests: XCTestCase {
     
     func test_knight_test_white_pawn_movableRoute() {
         // given
-        let blackKnight = Knight(team: .black, position: .init(row: .one, column: .b))
-        let whiteKnight = Knight(team: .white, position: .init(row: .eight, column: .b))
+        let blackKnight = Knight(team: .black)
+        let whiteKnight = Knight(team: .white)
         
         // then
-        XCTAssertEqual(blackKnight.movableRoute().map { $0.step }, [
+        XCTAssertEqual(blackKnight.movableRoute(at: .init(row: .one, column: .b)).map { $0.step }, [
             [
                 ChessPosition(row: .two, column: .b),
                 ChessPosition(row: .three, column: .a)
@@ -60,7 +60,7 @@ class PieceTests: XCTestCase {
             ]
         ])
         
-        XCTAssertEqual(whiteKnight.movableRoute().map { $0.step }, [
+        XCTAssertEqual(whiteKnight.movableRoute(at: .init(row: .eight, column: .b)).map { $0.step }, [
             [
                 ChessPosition(row: .seven, column: .b),
                 ChessPosition(row: .six, column: .a)
@@ -74,16 +74,16 @@ class PieceTests: XCTestCase {
     
     func test_rook_movableRoute() {
         // given
-        let blackRook = Rook(team: .black, position: .init(row: .one, column: .a))
-        let whiteRook = Rook(team: .white, position: .init(row: .eight, column: .h))
+        let blackRook = Rook(team: .black)
+        let whiteRook = Rook(team: .white)
         
         // then
-        XCTAssertEqual(blackRook.movableRoute().map { $0.step }, [
+        XCTAssertEqual(blackRook.movableRoute(at: .init(row: .one, column: .a)).map { $0.step }, [
             [ChessPosition(row: .two, column: .a)],
             [ChessPosition(row: .one, column: .b)]
         ])
         
-        XCTAssertEqual(whiteRook.movableRoute().map { $0.step }, [
+        XCTAssertEqual(whiteRook.movableRoute(at: .init(row: .eight, column: .h)).map { $0.step }, [
             [ChessPosition(row: .seven, column: .h)],
             [ChessPosition(row: .eight, column: .g)]
         ])
@@ -91,16 +91,16 @@ class PieceTests: XCTestCase {
     
     func test_bishop_movableRoute() {
         // given
-        let blackBishop = Bishop(team: .black, position: .init(row: .one, column: .c))
-        let whiteBishop = Bishop(team: .white, position: .init(row: .eight, column: .f))
+        let blackBishop = Bishop(team: .black)
+        let whiteBishop = Bishop(team: .white)
         
         // then
-        XCTAssertEqual(blackBishop.movableRoute().map { $0.step }, [
+        XCTAssertEqual(blackBishop.movableRoute(at: .init(row: .one, column: .c)).map { $0.step }, [
             [ChessPosition(row: .two, column: .b)],
             [ChessPosition(row: .two, column: .d)]
         ])
         
-        XCTAssertEqual(whiteBishop.movableRoute().map { $0.step }, [
+        XCTAssertEqual(whiteBishop.movableRoute(at: .init(row: .eight, column: .f)).map { $0.step }, [
             [ChessPosition(row: .seven, column: .e)],
             [ChessPosition(row: .seven, column: .g)]
         ])
@@ -108,11 +108,11 @@ class PieceTests: XCTestCase {
     
     func test_Queen_movableRoute() {
         // given
-        let blackQueen = Queen(team: .black, position: .init(row: .one, column: .e))
-        let whiteQueen = Queen(team: .white, position: .init(row: .eight, column: .e))
+        let blackQueen = Queen(team: .black)
+        let whiteQueen = Queen(team: .white)
         
         // then
-        XCTAssertEqual(blackQueen.movableRoute().map { $0.step }, [
+        XCTAssertEqual(blackQueen.movableRoute(at: .init(row: .one, column: .e)).map { $0.step }, [
             [ChessPosition(row: .one, column: .d)],
             [ChessPosition(row: .two, column: .d)],
             [ChessPosition(row: .two, column: .e)],
@@ -120,7 +120,7 @@ class PieceTests: XCTestCase {
             [ChessPosition(row: .one, column: .f)]
         ])
         
-        XCTAssertEqual(whiteQueen.movableRoute().map { $0.step }, [
+        XCTAssertEqual(whiteQueen.movableRoute(at: .init(row: .eight, column: .e)).map { $0.step }, [
             [ChessPosition(row: .seven, column: .e)],
             [ChessPosition(row: .seven, column: .d)],
             [ChessPosition(row: .eight, column: .d)],

--- a/Swift-Chessgame/Swift-ChessgameTests/PieceTests.swift
+++ b/Swift-Chessgame/Swift-ChessgameTests/PieceTests.swift
@@ -19,51 +19,33 @@ class PieceTests: XCTestCase {
         
     }
     
-    func test_pawn_movablePosition_at_leftTopEdge() {
-        // given
-        let pawn = Pawn(team: .white, position: .init(row: .one, column: .a))
-        let rightPosition = ChessPosition(row: .one, column: .b)
-        let downPosition = ChessPosition(row: .two, column: .a)
-        
-        // when
-        let movablePositions = pawn.movablePositions()
-        
-        // then
-        XCTAssertTrue(movablePositions.contains(rightPosition))
-        XCTAssertTrue(movablePositions.contains(downPosition))
-    }
-    
-    func test_pawn_movablePosition_at_rightDownEdge() {
-        // given
-        let pawn = Pawn(team: .white, position: .init(row: .eight, column: .h))
-        let leftPosition = ChessPosition(row: .seven, column: .h)
-        let upPosition = ChessPosition(row: .eight, column: .g)
-        
-        // when
-        let movablePositions = pawn.movablePositions()
-        
-        // then
-        XCTAssertTrue(movablePositions.contains(leftPosition))
-        XCTAssertTrue(movablePositions.contains(upPosition))
-    }
-    
-    func test_pawn_movablePosition_at_inside() {
+    func test_white_pawn_movablePosition() {
         // given
         let pawn = Pawn(team: .white, position: .init(row: .two, column: .b))
         
-        let upPosition = ChessPosition(row: .one, column: .b)
-        let downPosition = ChessPosition(row: .three, column: .b)
-        let leftPosition = ChessPosition(row: .two, column: .a)
-        let rightPosition = ChessPosition(row: .two, column: .c)
+        // when
+        let movablePositions = pawn.movablePositions()
         
+        // then
+        XCTAssertEqual(movablePositions, [
+            ChessPosition(row: .three, column: .b),
+            ChessPosition(row: .two, column: .a),
+            ChessPosition(row: .two, column: .c)
+        ])
+    }
+    
+    func test_black_pawn_movablePosition() {
+        // given
+        let pawn = Pawn(team: .black, position: .init(row: .seven, column: .b))
         
         // when
         let movablePositions = pawn.movablePositions()
         
         // then
-        XCTAssertTrue(movablePositions.contains(upPosition))
-        XCTAssertTrue(movablePositions.contains(downPosition))
-        XCTAssertTrue(movablePositions.contains(leftPosition))
-        XCTAssertTrue(movablePositions.contains(rightPosition))
+        XCTAssertEqual(movablePositions, [
+            ChessPosition(row: .six, column: .b),
+            ChessPosition(row: .seven, column: .a),
+            ChessPosition(row: .seven, column: .c)
+        ])
     }
 }

--- a/Swift-Chessgame/Swift-ChessgameTests/PieceTests.swift
+++ b/Swift-Chessgame/Swift-ChessgameTests/PieceTests.swift
@@ -19,33 +19,113 @@ class PieceTests: XCTestCase {
         
     }
     
-    func test_white_pawn_movablePosition() {
+    func test_black_pawn_movableRoute() {
         // given
-        let pawn = Pawn(team: .white, position: .init(row: .two, column: .b))
-        
-        // when
-        let movablePositions = pawn.movablePositions()
+        let pawn = Pawn(team: .black, position: .init(row: .two, column: .b))
         
         // then
-        XCTAssertEqual(movablePositions, [
-            ChessPosition(row: .three, column: .b),
-            ChessPosition(row: .two, column: .a),
-            ChessPosition(row: .two, column: .c)
+        XCTAssertEqual(pawn.movableRoute().map { $0.step }, [
+            [ChessPosition(row: .two, column: .a)],
+            [ChessPosition(row: .three, column: .b)],
+            [ChessPosition(row: .two, column: .c)]
         ])
     }
     
-    func test_black_pawn_movablePosition() {
+    func test_white_pawn_movableRoute() {
         // given
-        let pawn = Pawn(team: .black, position: .init(row: .seven, column: .b))
-        
-        // when
-        let movablePositions = pawn.movablePositions()
+        let pawn = Pawn(team: .white, position: .init(row: .seven, column: .b))
         
         // then
-        XCTAssertEqual(movablePositions, [
-            ChessPosition(row: .six, column: .b),
-            ChessPosition(row: .seven, column: .a),
-            ChessPosition(row: .seven, column: .c)
+        XCTAssertEqual(pawn.movableRoute().map { $0.step }, [
+            [ChessPosition(row: .six, column: .b)],
+            [ChessPosition(row: .seven, column: .a)],
+            [ChessPosition(row: .seven, column: .c)]
+        ])
+    }
+    
+    func test_knight_test_white_pawn_movableRoute() {
+        // given
+        let blackKnight = Knight(team: .black, position: .init(row: .one, column: .b))
+        let whiteKnight = Knight(team: .white, position: .init(row: .eight, column: .b))
+        
+        // then
+        XCTAssertEqual(blackKnight.movableRoute().map { $0.step }, [
+            [
+                ChessPosition(row: .two, column: .b),
+                ChessPosition(row: .three, column: .a)
+            ],
+            [
+                ChessPosition(row: .two, column: .b),
+                ChessPosition(row: .three, column: .c)
+            ]
+        ])
+        
+        XCTAssertEqual(whiteKnight.movableRoute().map { $0.step }, [
+            [
+                ChessPosition(row: .seven, column: .b),
+                ChessPosition(row: .six, column: .a)
+            ],
+            [
+                ChessPosition(row: .seven, column: .b),
+                ChessPosition(row: .six, column: .c)
+            ]
+        ])
+    }
+    
+    func test_rook_movableRoute() {
+        // given
+        let blackRook = Rook(team: .black, position: .init(row: .one, column: .a))
+        let whiteRook = Rook(team: .white, position: .init(row: .eight, column: .h))
+        
+        // then
+        XCTAssertEqual(blackRook.movableRoute().map { $0.step }, [
+            [ChessPosition(row: .two, column: .a)],
+            [ChessPosition(row: .one, column: .b)]
+        ])
+        
+        XCTAssertEqual(whiteRook.movableRoute().map { $0.step }, [
+            [ChessPosition(row: .seven, column: .h)],
+            [ChessPosition(row: .eight, column: .g)]
+        ])
+    }
+    
+    func test_bishop_movableRoute() {
+        // given
+        let blackBishop = Bishop(team: .black, position: .init(row: .one, column: .c))
+        let whiteBishop = Bishop(team: .white, position: .init(row: .eight, column: .f))
+        
+        // then
+        XCTAssertEqual(blackBishop.movableRoute().map { $0.step }, [
+            [ChessPosition(row: .two, column: .b)],
+            [ChessPosition(row: .two, column: .d)]
+        ])
+        
+        XCTAssertEqual(whiteBishop.movableRoute().map { $0.step }, [
+            [ChessPosition(row: .seven, column: .e)],
+            [ChessPosition(row: .seven, column: .g)]
+        ])
+    }
+    
+    func test_Queen_movableRoute() {
+        // given
+        let blackQueen = Queen(team: .black, position: .init(row: .one, column: .e))
+        let whiteQueen = Queen(team: .white, position: .init(row: .eight, column: .e))
+        
+        // then
+        XCTAssertEqual(blackQueen.movableRoute().map { $0.step }, [
+            [ChessPosition(row: .one, column: .d)],
+            [ChessPosition(row: .two, column: .d)],
+            [ChessPosition(row: .two, column: .e)],
+            [ChessPosition(row: .two, column: .f)],
+            [ChessPosition(row: .one, column: .f)]
+        ])
+        
+        XCTAssertEqual(whiteQueen.movableRoute().map { $0.step }, [
+            [ChessPosition(row: .seven, column: .e)],
+            [ChessPosition(row: .seven, column: .d)],
+            [ChessPosition(row: .eight, column: .d)],
+            [ChessPosition(row: .eight, column: .f)],
+            [ChessPosition(row: .seven, column: .f)]
         ])
     }
 }

--- a/Swift-Chessgame/Swift-ChessgameTests/PieceTests.swift
+++ b/Swift-Chessgame/Swift-ChessgameTests/PieceTests.swift
@@ -1,0 +1,69 @@
+//
+//  PieceTests.swift
+//  Swift-Chessgame
+//
+//  Copyright (c) 2022 woongs All rights reserved.
+//
+
+
+import XCTest
+@testable import Swift_Chessgame
+
+class PieceTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        
+    }
+
+    override func tearDownWithError() throws {
+        
+    }
+    
+    func test_pawn_movablePosition_at_leftTopEdge() {
+        // given
+        let pawn = Pawn(team: .white, position: .init(row: .one, column: .a))
+        let rightPosition = ChessPosition(row: .one, column: .b)
+        let downPosition = ChessPosition(row: .two, column: .a)
+        
+        // when
+        let movablePositions = pawn.movablePositions()
+        
+        // then
+        XCTAssertTrue(movablePositions.contains(rightPosition))
+        XCTAssertTrue(movablePositions.contains(downPosition))
+    }
+    
+    func test_pawn_movablePosition_at_rightDownEdge() {
+        // given
+        let pawn = Pawn(team: .white, position: .init(row: .eight, column: .h))
+        let leftPosition = ChessPosition(row: .seven, column: .h)
+        let upPosition = ChessPosition(row: .eight, column: .g)
+        
+        // when
+        let movablePositions = pawn.movablePositions()
+        
+        // then
+        XCTAssertTrue(movablePositions.contains(leftPosition))
+        XCTAssertTrue(movablePositions.contains(upPosition))
+    }
+    
+    func test_pawn_movablePosition_at_inside() {
+        // given
+        let pawn = Pawn(team: .white, position: .init(row: .two, column: .b))
+        
+        let upPosition = ChessPosition(row: .one, column: .b)
+        let downPosition = ChessPosition(row: .three, column: .b)
+        let leftPosition = ChessPosition(row: .two, column: .a)
+        let rightPosition = ChessPosition(row: .two, column: .c)
+        
+        
+        // when
+        let movablePositions = pawn.movablePositions()
+        
+        // then
+        XCTAssertTrue(movablePositions.contains(upPosition))
+        XCTAssertTrue(movablePositions.contains(downPosition))
+        XCTAssertTrue(movablePositions.contains(leftPosition))
+        XCTAssertTrue(movablePositions.contains(rightPosition))
+    }
+}


### PR DESCRIPTION
아직 구현을 많이 못해서 1주차 관련 내용 PR 입니다.
시간 투자를 많이 못했고, 이동 관련 로직들을 어떻게 처리할지 고민하다가 시간이 오래 걸렸습니다.. 😭

1 -> 2주차로 넘어가는 주요 포인트가 1주차에 작성했던 로직에 뷰를 붙일 때 어떤 변화들이 필요할지 생각해보라는 의도라고 생각을 했습니다.
그래서 1주차가 완전히 마무리가 되지 않아 무리하게 뷰 부분을 구현하지는 않았습니다 🥲

지난 리뷰를 받고 각 부분이 어떤 역할을 맡을지 제 나름의 판단이 제대로 서지 않은 상태였다는 걸 느껴서 그 부분을 생각을 해봤습니다. 
사용자의 입력을 받아 처리하는 부분은 별도로 만들고 
여기서 입력을 해석해 Board에 명령을 내리는 구조를 생각했습니다.

Board
- 체스말, 게임의 점수를 관리합니다.

Piece
- 위치에 따른 자신이 이동 가능한 한 스텝의 경로를 제공합니다.
- 중간 경로에 다른 말이 있을 경우 멈춰야 하기 때문에 `PieceRoute`를 추가했습니다.
- Piece가 보여지는 부분이 String이 될 수도 있고 다른 형태가 될 수도 있겠다 생각해서 `PiecePresentation` 모델을 하나 만들었는데,
현 단계에서는 좀 불필요한 과정이었다는 생각도 드네요.. 😥

